### PR TITLE
Add support of multiple images for a book

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,9 +123,26 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-hateoas</artifactId>
 		</dependency>
+		<!-- Mongock Spring Boot Starter -->
+		<dependency>
+			<groupId>io.mongock</groupId>
+			<artifactId>mongock-springboot</artifactId>
+		</dependency>
+		<!-- Mongock MongoDB Spring Data v4 Driver -->
+		<dependency>
+			<groupId>io.mongock</groupId>
+			<artifactId>mongodb-springdata-v4-driver</artifactId>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>
+			<dependency>
+				<groupId>io.mongock</groupId>
+				<artifactId>mongock-bom</artifactId>
+				<version>5.5.1</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dependencies</artifactId>

--- a/src/main/java/com/kirjaswappi/backend/common/configs/MongockConfig.java
+++ b/src/main/java/com/kirjaswappi/backend/common/configs/MongockConfig.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 KirjaSwappi or KirjaSwappi affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+package com.kirjaswappi.backend.common.configs;
+
+import io.mongock.driver.mongodb.springdata.v4.SpringDataMongoV4Driver;
+import io.mongock.runner.springboot.MongockSpringboot;
+import io.mongock.runner.springboot.base.MongockInitializingBeanRunner;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+@Configuration
+@Profile("cloud")
+public class MongockConfig {
+  @Bean
+  public MongockInitializingBeanRunner mongockInitializingBeanRunner(MongoTemplate mongoTemplate,
+      ApplicationContext applicationContext) {
+    return MongockSpringboot.builder()
+        .setDriver(SpringDataMongoV4Driver.withDefaultLock(mongoTemplate))
+        .setSpringContext(applicationContext)
+        .addMigrationScanPackage("com.kirjaswappi.backend.common.migrations")
+        .buildInitializingBeanRunner();
+  }
+}

--- a/src/main/java/com/kirjaswappi/backend/common/migrations/MigrateCoverPhotoToCoverPhotos.java
+++ b/src/main/java/com/kirjaswappi/backend/common/migrations/MigrateCoverPhotoToCoverPhotos.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025 KirjaSwappi or KirjaSwappi affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+package com.kirjaswappi.backend.common.migrations;
+
+import java.util.Set;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+
+import org.bson.Document;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+
+@ChangeUnit(id = "migrateCoverPhotoToCoverPhotos", order = "0001", author = "mahiuddinalkamal")
+public class MigrateCoverPhotoToCoverPhotos {
+
+  private final MongoTemplate mongoTemplate;
+
+  public MigrateCoverPhotoToCoverPhotos(MongoTemplate mongoTemplate) {
+    this.mongoTemplate = mongoTemplate;
+  }
+
+  @Execution
+  public void executeMigration() {
+    Query query = new Query(Criteria.where("coverPhoto").ne(null));
+    var books = mongoTemplate.find(query, Document.class, "books");
+
+    for (var book : books) {
+      String oldCoverPhoto = book.getString("coverPhoto");
+      if (oldCoverPhoto != null && !oldCoverPhoto.isBlank()) {
+        Update update = new Update()
+            .unset("coverPhoto")
+            .set("coverPhotos", Set.of(oldCoverPhoto));
+
+        mongoTemplate.updateFirst(
+            new Query(Criteria.where("_id").is(book.getObjectId("_id"))),
+            update,
+            "books");
+      }
+    }
+  }
+
+  @RollbackExecution
+  public void rollback() {
+    // skip it
+  }
+}

--- a/src/main/java/com/kirjaswappi/backend/http/dtos/requests/CreateBookRequest.java
+++ b/src/main/java/com/kirjaswappi/backend/http/dtos/requests/CreateBookRequest.java
@@ -43,8 +43,8 @@ public class CreateBookRequest {
   @Schema(description = "The genres of the book.", example = "[\"Fiction\"]", requiredMode = REQUIRED)
   private List<String> genres;
 
-  @Schema(description = "The cover photo of the book.", example = "book-cover-photo.jpg", requiredMode = REQUIRED)
-  private MultipartFile coverPhoto;
+  @Schema(description = "The cover photos of the book.", example = "book-cover-photo.jpg", requiredMode = REQUIRED)
+  private List<MultipartFile> coverPhotos;
 
   @Schema(description = "The user ID of the book owner.", example = "123456", requiredMode = REQUIRED)
   private String ownerId;
@@ -67,21 +67,20 @@ public class CreateBookRequest {
   public Book toEntity() {
     this.validateProperties();
     var book = new Book();
-    book.setTitle(title);
-    book.setAuthor(author);
-    book.setDescription(description);
-    book.setLanguage(Language.fromCode(language));
-    book.setCondition(Condition.fromCode(condition));
+    book.setTitle(this.title);
+    book.setAuthor(this.author);
+    book.setDescription(this.description);
+    book.setLanguage(Language.fromCode(this.language));
+    book.setCondition(Condition.fromCode(this.condition));
     book.setGenres(this.genres.stream().map(Genre::new).toList());
-    book.setCoverPhotoFile(coverPhoto);
+    book.setCoverPhotoFiles(this.coverPhotos);
     var user = new User();
-    user.setId(ownerId);
+    user.setId(this.ownerId);
     book.setOwner(user);
     return book;
   }
 
   private void validateProperties() {
-    ValidationUtil.validateMediaType(coverPhoto);
     if (!ValidationUtil.validateNotBlank(this.title)) {
       throw new BadRequestException("bookTitleCannotBeBlank", this.title);
     }
@@ -97,15 +96,17 @@ public class CreateBookRequest {
     if (this.genres == null || this.genres.isEmpty()) {
       throw new BadRequestException("atLeastOneGenreNeeded", this.genres);
     }
-    if (this.coverPhoto == null) {
-      throw new BadRequestException("coverPhotoIsRequired");
+    if (!ValidationUtil.validateNotBlank(this.swapCondition)) {
+      throw new BadRequestException("swapConditionIsRequired");
+    }
+    if (this.coverPhotos == null) {
+      throw new BadRequestException("atLeastOneCoverPhotoIsRequired");
+    }
+    for (var coverPhoto : this.coverPhotos) {
+      ValidationUtil.validateMediaType(coverPhoto);
     }
     if (!ValidationUtil.validateNotBlank(this.ownerId)) {
       throw new BadRequestException("ownerIdCannotBeBlank", this.ownerId);
     }
-    if (!ValidationUtil.validateNotBlank(this.swapCondition)) {
-      throw new BadRequestException("swapConditionIsRequired");
-    }
   }
-
 }

--- a/src/main/java/com/kirjaswappi/backend/http/dtos/requests/UpdateBookRequest.java
+++ b/src/main/java/com/kirjaswappi/backend/http/dtos/requests/UpdateBookRequest.java
@@ -45,8 +45,8 @@ public class UpdateBookRequest {
   @Schema(description = "The genres of the book.", example = "[\"Fiction\"]", requiredMode = REQUIRED)
   private List<String> genres;
 
-  @Schema(description = "The cover photo of the book.", example = "book-cover-photo.jpg", requiredMode = REQUIRED)
-  private MultipartFile coverPhoto;
+  @Schema(description = "The cover photos of the book.", example = "book-cover-photo.jpg", requiredMode = REQUIRED)
+  private List<MultipartFile> coverPhotos;
 
   @Schema(description = "Swap condition of the book in JSON format.", requiredMode = REQUIRED, example = "{\n" +
       "  \"conditionType\": \"ByBooks\",\n" +
@@ -66,19 +66,18 @@ public class UpdateBookRequest {
   public Book toEntity() {
     this.validateProperties();
     var book = new Book();
-    book.setId(id);
-    book.setTitle(title);
-    book.setAuthor(author);
-    book.setDescription(description);
-    book.setLanguage(Language.fromCode(language));
-    book.setCondition(Condition.fromCode(condition));
+    book.setId(this.id);
+    book.setTitle(this.title);
+    book.setAuthor(this.author);
+    book.setDescription(this.description);
+    book.setLanguage(Language.fromCode(this.language));
+    book.setCondition(Condition.fromCode(this.condition));
     book.setGenres(this.genres.stream().map(Genre::new).toList());
-    book.setCoverPhotoFile(coverPhoto);
+    book.setCoverPhotoFiles(this.coverPhotos);
     return book;
   }
 
   private void validateProperties() {
-    ValidationUtil.validateMediaType(coverPhoto);
     if (!ValidationUtil.validateNotBlank(this.id)) {
       throw new BadRequestException("bookIdCannotBeBlank", this.id);
     }
@@ -97,11 +96,14 @@ public class UpdateBookRequest {
     if (this.genres == null || this.genres.isEmpty()) {
       throw new BadRequestException("atLeastOneGenreNeeded", this.genres);
     }
-    if (this.coverPhoto == null) {
-      throw new BadRequestException("coverPhotoIsRequired");
-    }
     if (!ValidationUtil.validateNotBlank(this.swapCondition)) {
       throw new BadRequestException("swapConditionIsRequired");
+    }
+    if (this.coverPhotos == null) {
+      throw new BadRequestException("atLeastOneCoverPhotoIsRequired");
+    }
+    for (var coverPhoto : this.coverPhotos) {
+      ValidationUtil.validateMediaType(coverPhoto);
     }
   }
 }

--- a/src/main/java/com/kirjaswappi/backend/http/dtos/responses/BookListResponse.java
+++ b/src/main/java/com/kirjaswappi/backend/http/dtos/responses/BookListResponse.java
@@ -35,6 +35,6 @@ public class BookListResponse {
     this.language = entity.getLanguage().getCode();
     this.description = entity.getDescription();
     this.condition = entity.getCondition().getCode();
-    this.coverPhotoUrl = entity.getCoverPhoto() != null ? entity.getCoverPhoto() : null;
+    this.coverPhotoUrl = entity.getCoverPhotos() != null ? entity.getCoverPhotos().get(0) : null;
   }
 }

--- a/src/main/java/com/kirjaswappi/backend/http/dtos/responses/BookResponse.java
+++ b/src/main/java/com/kirjaswappi/backend/http/dtos/responses/BookResponse.java
@@ -25,7 +25,7 @@ public class BookResponse {
   private final String language;
   private final String description;
   private final String condition;
-  private final String coverPhotoUrl;
+  private final List<String> coverPhotoUrls;
   private OwnerResponse owner;
   private SwapConditionResponse swapCondition;
 
@@ -37,7 +37,7 @@ public class BookResponse {
     this.language = entity.getLanguage() == null ? null : entity.getLanguage().getCode();
     this.description = entity.getDescription() == null ? null : entity.getDescription();
     this.condition = entity.getCondition() == null ? null : entity.getCondition().getCode();
-    this.coverPhotoUrl = entity.getCoverPhoto() == null ? null : entity.getCoverPhoto();
+    this.coverPhotoUrls = entity.getCoverPhotos() == null ? null : entity.getCoverPhotos();
     this.owner = entity.getOwner() == null ? null : new OwnerResponse(entity.getOwner());
     this.swapCondition = entity.getSwapCondition() == null ? null
         : new SwapConditionResponse(entity.getSwapCondition());

--- a/src/main/java/com/kirjaswappi/backend/jpa/daos/BookDao.java
+++ b/src/main/java/com/kirjaswappi/backend/jpa/daos/BookDao.java
@@ -44,7 +44,7 @@ public class BookDao {
   private String condition;
 
   @NotNull
-  private String coverPhoto;
+  private List<String> coverPhotos;
 
   @NotNull
   @DBRef

--- a/src/main/java/com/kirjaswappi/backend/mapper/BookMapper.java
+++ b/src/main/java/com/kirjaswappi/backend/mapper/BookMapper.java
@@ -4,6 +4,8 @@
  */
 package com.kirjaswappi.backend.mapper;
 
+import java.util.List;
+
 import lombok.NoArgsConstructor;
 
 import org.springframework.stereotype.Component;
@@ -26,14 +28,14 @@ public class BookMapper {
     entity.setLanguage(Language.fromCode(dao.getLanguage()));
     entity.setCondition(Condition.fromCode(dao.getCondition()));
     entity.setGenres(dao.getGenres().stream().map(GenreMapper::toEntity).toList());
-    if (dao.getCoverPhoto() != null) {
-      entity.setCoverPhoto(dao.getCoverPhoto());
+    if (dao.getCoverPhotos() != null) {
+      entity.setCoverPhotos(dao.getCoverPhotos());
     }
     entity.setSwapCondition(SwapConditionMapper.toEntity(dao.getSwapCondition()));
     return entity;
   }
 
-  public static Book toEntity(BookDao dao, String imageUrl) {
+  public static Book toEntity(BookDao dao, List<String> imageUrls) {
     var entity = new Book();
     entity.setId(dao.getId());
     entity.setTitle(dao.getTitle());
@@ -42,7 +44,7 @@ public class BookMapper {
     entity.setLanguage(Language.fromCode(dao.getLanguage()));
     entity.setCondition(Condition.fromCode(dao.getCondition()));
     entity.setGenres(dao.getGenres().stream().map(GenreMapper::toEntity).toList());
-    entity.setCoverPhoto(imageUrl);
+    entity.setCoverPhotos(imageUrls);
     entity.setSwapCondition(SwapConditionMapper.toEntity(dao.getSwapCondition()));
     return entity;
   }
@@ -64,7 +66,7 @@ public class BookMapper {
     dao.setCondition(entity.getCondition().getCode());
     dao.setSwapCondition(SwapConditionMapper.toDao(entity.getSwapCondition()));
     dao.setGenres(entity.getGenres() == null ? null : entity.getGenres().stream().map(GenreMapper::toDao).toList());
-    dao.setCoverPhoto(entity.getCoverPhoto() == null ? null : entity.getCoverPhoto());
+    dao.setCoverPhotos(entity.getCoverPhotos() == null ? null : entity.getCoverPhotos());
     dao.setOwner(entity.getOwner() == null ? null : UserMapper.toDao(entity.getOwner()));
     return dao;
   }

--- a/src/main/java/com/kirjaswappi/backend/service/GenreService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/GenreService.java
@@ -82,4 +82,10 @@ public class GenreService {
         .orElseThrow(() -> new GenreNotFoundException(genreId));
     return GenreMapper.toEntity(dao);
   }
+
+  public Genre getGenreByName(String genreName) {
+    var dao = genreRepository.findByName(genreName)
+        .orElseThrow(() -> new GenreNotFoundException(genreName));
+    return GenreMapper.toEntity(dao);
+  }
 }

--- a/src/main/java/com/kirjaswappi/backend/service/PhotoService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/PhotoService.java
@@ -62,10 +62,10 @@ public class PhotoService {
     return imageService.getDownloadUrl(uniqueId);
   }
 
-  public String addBookCoverPhoto(MultipartFile file, String bookId) {
-    var uniqueId = bookId + "-" + "BookCoverPhoto";
+  public void addBookCoverPhoto(MultipartFile file, String uniqueId) {
+    // var uniqueId = bookId + "-" + "BookCoverPhoto";
     imageService.uploadImage(file, uniqueId);
-    return uniqueId;
+    // return uniqueId;
   }
 
   public void deleteBookCoverPhoto(String uniqueId) {

--- a/src/main/java/com/kirjaswappi/backend/service/PhotoService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/PhotoService.java
@@ -63,9 +63,7 @@ public class PhotoService {
   }
 
   public void addBookCoverPhoto(MultipartFile file, String uniqueId) {
-    // var uniqueId = bookId + "-" + "BookCoverPhoto";
     imageService.uploadImage(file, uniqueId);
-    // return uniqueId;
   }
 
   public void deleteBookCoverPhoto(String uniqueId) {

--- a/src/main/java/com/kirjaswappi/backend/service/UserService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/UserService.java
@@ -4,6 +4,7 @@
  */
 package com.kirjaswappi.backend.service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -71,8 +72,12 @@ public class UserService {
         .orElseThrow(() -> new UserNotFoundException(id));
     if (userDao.getBooks() != null) {
       userDao.getBooks().forEach(bookDao -> {
-        var imageUrl = photoService.getBookCoverPhoto(bookDao.getCoverPhoto());
-        bookDao.setCoverPhoto(imageUrl);
+        var imageUrls = new ArrayList<String>();
+        bookDao.getCoverPhotos().forEach(uniqueId -> {
+          var imageUrl = photoService.getBookCoverPhoto(uniqueId);
+          imageUrls.add(imageUrl);
+        });
+        bookDao.setCoverPhotos(imageUrls);
       });
     }
     return UserMapper.toEntity(userDao);
@@ -82,8 +87,12 @@ public class UserService {
     return userRepository.findAll().stream().map(userDao -> {
       if (userDao.getBooks() != null) {
         userDao.getBooks().forEach(bookDao -> {
-          var imageUrl = photoService.getBookCoverPhoto(bookDao.getCoverPhoto());
-          bookDao.setCoverPhoto(imageUrl);
+          var imageUrls = new ArrayList<String>();
+          bookDao.getCoverPhotos().forEach(uniqueId -> {
+            var imageUrl = photoService.getBookCoverPhoto(uniqueId);
+            imageUrls.add(imageUrl);
+          });
+          bookDao.setCoverPhotos(imageUrls);
         });
       }
       return UserMapper.toEntity(userDao);

--- a/src/main/java/com/kirjaswappi/backend/service/entities/Book.java
+++ b/src/main/java/com/kirjaswappi/backend/service/entities/Book.java
@@ -28,8 +28,8 @@ public class Book {
   private Language language;
   private Condition condition;
   private List<Genre> genres;
-  private String coverPhoto;
-  private MultipartFile coverPhotoFile;
+  private List<String> coverPhotos;
+  private List<MultipartFile> coverPhotoFiles;
   private User owner;
   private SwapCondition swapCondition;
 }

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -96,6 +96,9 @@ languageCannotBeBlank=Please provide a book language.
 #NOTR: Error message in case of blank book genre
 atLeastOneGenreNeeded=Please provide at least one book genre.
 
+#NOTR: Error message in case of a blank book cover photo
+atLeastOneCoverPhotoIsRequired=Please provide at least one book cover photo.
+
 #NOTR: Error message in case of blank book owner ID
 ownerIdCannotBeBlank=Please provide book owner ID.
 


### PR DESCRIPTION
This PR enables adding multiple images for a book.

Some breaking changes:

1. Add Book API:
- Use `coverPhotos` instead of `coverPhoto`
- `coverPhotos`expects a List of Multipart files.

2. Get Book by ID API:
- response field changed from `coverPhotoUrl` to `coverPhotoUrls`
- `coverPhotoUrls` is an Array of URLs for images.

3. Get User by ID API (same changes as 2):
- response field changed from `coverPhotoUrl` to `coverPhotoUrls`
- `coverPhotoUrls` is an Array of URLs for images.