### PR TITLE
Fix: for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   publish_and_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix for [https://github.com/kirjaswappi/kirjaswappi-backend/security/code-scanning/16](https://github.com/kirjaswappi/kirjaswappi-backend/security/code-scanning/16)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Based on the workflow's steps:
- `contents: read` is needed for actions like checking out the repository.
- `packages: write` is required for deploying to GitHub Packages.
- `contents: write` is needed for creating a release.

The `permissions` block will be added at the root of the workflow to apply to all jobs.
