### PR TITLE
Potential fix for code scanning alert no. 6: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/com/kirjaswappi/backend/common/configs/CloudSecurityConfig.java
+++ b/src/main/java/com/kirjaswappi/backend/common/configs/CloudSecurityConfig.java
@@ -52,11 +52,11 @@ public class CloudSecurityConfig {
   public SecurityFilterChain defaultSecurityFilterChain(FilterApiRequest filterApiRequest, HttpSecurity http)
       throws Exception {
     return http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-        .csrf(csrf -> csrf.disable()) // Disable CSRF protection
+        .csrf(csrf -> csrf.ignoringRequestMatchers(HEALTH, API_DOCS, SWAGGER_UI, API_BASE + AUTHENTICATE,
+            API_BASE + AUTHENTICATE + REFRESH)) // Enable CSRF protection but ignore specific endpoints
         .authorizeHttpRequests(authorize -> authorize
             .requestMatchers(HEALTH, API_DOCS, SWAGGER_UI, API_BASE + AUTHENTICATE,
                 API_BASE + AUTHENTICATE + REFRESH)
-            .permitAll()
             .requestMatchers(POST, API_BASE + ADMIN_USERS).hasAuthority(ADMIN)
             .requestMatchers(GET, API_BASE + ADMIN_USERS).hasAuthority(ADMIN)
             .requestMatchers(DELETE, API_BASE + ADMIN_USERS).hasAuthority(ADMIN)


### PR DESCRIPTION
Potential fix for [https://github.com/kirjaswappi/kirjaswappi-backend/security/code-scanning/6](https://github.com/kirjaswappi/kirjaswappi-backend/security/code-scanning/6)

To fix the issue, CSRF protection should be enabled by removing the `csrf.disable()` call. If there are specific endpoints that do not require CSRF protection (e.g., public APIs), they can be explicitly excluded from CSRF protection using Spring Security's `ignoringAntMatchers` or similar configuration. This ensures that the application remains secure while allowing flexibility for specific use cases.

The changes will involve:
1. Removing the `csrf.disable()` line in the `defaultSecurityFilterChain` method.
2. Optionally, configuring CSRF protection to ignore specific endpoints if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
