### PR TITLE
Fix: resolve inbox book cover photo IDs to presigned URLs

### DIFF
--- a/src/main/java/com/kirjaswappi/backend/http/controllers/InboxController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/InboxController.java
@@ -14,6 +14,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,12 +26,16 @@ import com.kirjaswappi.backend.http.dtos.responses.InboxItemResponse;
 import com.kirjaswappi.backend.service.InboxService;
 import com.kirjaswappi.backend.service.PhotoService;
 import com.kirjaswappi.backend.service.entities.SwapRequest;
+import com.kirjaswappi.backend.service.exceptions.ImageUrlFetchFailureException;
+import com.kirjaswappi.backend.service.exceptions.PhotoNotFoundException;
 
 @RestController
 @RequestMapping(API_BASE + INBOX)
 @Validated
 @Tag(name = "Inbox", description = "API for managing user inbox and swap request notifications")
 public class InboxController {
+  private static final Logger logger = LoggerFactory.getLogger(InboxController.class);
+
   @Autowired
   private InboxService inboxService;
 
@@ -62,7 +68,8 @@ public class InboxController {
           if (rawCoverPhotoId != null) {
             try {
               item.setBookCoverPhotoUrl(photoService.getBookCoverPhoto(rawCoverPhotoId));
-            } catch (Exception e) {
+            } catch (PhotoNotFoundException | ImageUrlFetchFailureException e) {
+              logger.warn("Failed to resolve cover photo for inbox item {}: {}", swapRequest.id(), e.getMessage());
               item.setBookCoverPhotoUrl(null);
             }
           }

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/InboxController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/InboxController.java
@@ -69,7 +69,7 @@ public class InboxController {
             try {
               item.setBookCoverPhotoUrl(photoService.getBookCoverPhoto(rawCoverPhotoId));
             } catch (PhotoNotFoundException | ImageUrlFetchFailureException e) {
-              logger.warn("Failed to resolve cover photo for inbox item {}: {}", swapRequest.id(), e.getMessage());
+              logger.warn("Failed to resolve cover photo for inbox item {}", swapRequest.id(), e);
               item.setBookCoverPhotoUrl(null);
             }
           }

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/InboxController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/InboxController.java
@@ -64,13 +64,13 @@ public class InboxController {
           InboxItemResponse item = new InboxItemResponse(swapRequest);
 
           // Resolve book cover photo ID to presigned URL
-          String rawCoverPhotoId = item.getBookCoverPhotoUrl();
-          if (rawCoverPhotoId != null) {
+          String coverPhotoId = item.getBookCoverPhotoReference();
+          if (coverPhotoId != null) {
             try {
-              item.setBookCoverPhotoUrl(photoService.getBookCoverPhoto(rawCoverPhotoId));
+              item.setBookCoverPhotoReference(photoService.getBookCoverPhoto(coverPhotoId));
             } catch (PhotoNotFoundException | ImageUrlFetchFailureException e) {
               logger.warn("Failed to resolve cover photo for inbox item {}", swapRequest.id(), e);
-              item.setBookCoverPhotoUrl(null);
+              item.setBookCoverPhotoReference(null);
             }
           }
 

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/InboxController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/InboxController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 
 import com.kirjaswappi.backend.http.dtos.responses.InboxItemResponse;
 import com.kirjaswappi.backend.service.InboxService;
+import com.kirjaswappi.backend.service.PhotoService;
 import com.kirjaswappi.backend.service.entities.SwapRequest;
 
 @RestController
@@ -31,6 +32,9 @@ import com.kirjaswappi.backend.service.entities.SwapRequest;
 public class InboxController {
   @Autowired
   private InboxService inboxService;
+
+  @Autowired
+  private PhotoService photoService;
 
   @GetMapping
   @Operation(summary = "Get unified inbox", description = "Retrieve all swap requests for the user (both sent and received) in a unified inbox sorted by latest messages with optional filtering and sorting", responses = {
@@ -52,6 +56,17 @@ public class InboxController {
     List<InboxItemResponse> response = swapRequests.stream()
         .map(swapRequest -> {
           InboxItemResponse item = new InboxItemResponse(swapRequest);
+
+          // Resolve book cover photo ID to presigned URL
+          String rawCoverPhotoId = item.getBookCoverPhotoUrl();
+          if (rawCoverPhotoId != null) {
+            try {
+              item.setBookCoverPhotoUrl(photoService.getBookCoverPhoto(rawCoverPhotoId));
+            } catch (Exception e) {
+              item.setBookCoverPhotoUrl(null);
+            }
+          }
+
           // Add unread message count using cached version
           long unreadCount = inboxService.getUnreadMessageCount(userId, swapRequest.id());
           item.setUnreadMessageCount(unreadCount);

--- a/src/main/java/com/kirjaswappi/backend/http/dtos/responses/InboxItemResponse.java
+++ b/src/main/java/com/kirjaswappi/backend/http/dtos/responses/InboxItemResponse.java
@@ -65,6 +65,16 @@ public class InboxItemResponse {
     return conversationType;
   }
 
+  public String getBookCoverPhotoUrl() {
+    return bookToSwapWith != null ? bookToSwapWith.coverPhotoUrl : null;
+  }
+
+  public void setBookCoverPhotoUrl(String url) {
+    if (bookToSwapWith != null) {
+      bookToSwapWith.coverPhotoUrl = url;
+    }
+  }
+
   @Getter
   @Setter
   static class UserSummaryResponse {

--- a/src/main/java/com/kirjaswappi/backend/http/dtos/responses/InboxItemResponse.java
+++ b/src/main/java/com/kirjaswappi/backend/http/dtos/responses/InboxItemResponse.java
@@ -67,14 +67,14 @@ public class InboxItemResponse {
   }
 
   @JsonIgnore
-  public String getBookCoverPhotoUrl() {
+  public String getBookCoverPhotoReference() {
     return bookToSwapWith != null ? bookToSwapWith.coverPhotoUrl : null;
   }
 
   @JsonIgnore
-  public void setBookCoverPhotoUrl(String url) {
+  public void setBookCoverPhotoReference(String value) {
     if (bookToSwapWith != null) {
-      bookToSwapWith.coverPhotoUrl = url;
+      bookToSwapWith.coverPhotoUrl = value;
     }
   }
 

--- a/src/main/java/com/kirjaswappi/backend/http/dtos/responses/InboxItemResponse.java
+++ b/src/main/java/com/kirjaswappi/backend/http/dtos/responses/InboxItemResponse.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 import lombok.Getter;
 import lombok.Setter;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.kirjaswappi.backend.service.entities.SwapRequest;
 import com.kirjaswappi.backend.service.entities.User;
 
@@ -65,10 +66,12 @@ public class InboxItemResponse {
     return conversationType;
   }
 
+  @JsonIgnore
   public String getBookCoverPhotoUrl() {
     return bookToSwapWith != null ? bookToSwapWith.coverPhotoUrl : null;
   }
 
+  @JsonIgnore
   public void setBookCoverPhotoUrl(String url) {
     if (bookToSwapWith != null) {
       bookToSwapWith.coverPhotoUrl = url;

--- a/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/InboxControllerTest.java
+++ b/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/InboxControllerTest.java
@@ -26,6 +26,7 @@ import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import com.kirjaswappi.backend.common.http.controllers.mockMvc.config.CustomMockMvcConfiguration;
 import com.kirjaswappi.backend.http.controllers.InboxController;
 import com.kirjaswappi.backend.service.InboxService;
+import com.kirjaswappi.backend.service.PhotoService;
 import com.kirjaswappi.backend.service.entities.Book;
 import com.kirjaswappi.backend.service.entities.ChatMessage;
 import com.kirjaswappi.backend.service.entities.SwapRequest;
@@ -46,6 +47,9 @@ class InboxControllerTest {
 
   @MockitoBean
   private InboxService inboxService;
+
+  @MockitoBean
+  private PhotoService photoService;
 
   @Test
   @DisplayName("Should return unified inbox successfully")

--- a/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/InboxControllerTest.java
+++ b/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/InboxControllerTest.java
@@ -481,7 +481,7 @@ class InboxControllerTest {
     mockMvc.perform(get(API_PATH)
         .with(withUser("receiver123")))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$[0].bookToSwapWith.coverPhotoUrl").doesNotExist());
+        .andExpect(jsonPath("$[0].bookToSwapWith.coverPhotoUrl").value((Object) null));
 
     verify(photoService).getBookCoverPhoto("missing-photo-id");
   }

--- a/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/InboxControllerTest.java
+++ b/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/InboxControllerTest.java
@@ -35,6 +35,7 @@ import com.kirjaswappi.backend.service.enums.Condition;
 import com.kirjaswappi.backend.service.enums.SwapStatus;
 import com.kirjaswappi.backend.service.enums.SwapType;
 import com.kirjaswappi.backend.service.exceptions.BadRequestException;
+import com.kirjaswappi.backend.service.exceptions.PhotoNotFoundException;
 import com.kirjaswappi.backend.service.exceptions.UserNotFoundException;
 
 @WebMvcTest(InboxController.class)
@@ -384,6 +385,105 @@ class InboxControllerTest {
         .andExpect(status().isUnauthorized());
 
     verifyNoInteractions(inboxService);
+  }
+
+  @Test
+  @DisplayName("Should resolve book cover photo ID to presigned URL")
+  void shouldResolveBookCoverPhotoToPresignedUrl() throws Exception {
+    User sender = User.builder()
+        .id("sender123")
+        .firstName("John")
+        .lastName("Doe")
+        .build();
+
+    User receiver = User.builder()
+        .id("receiver123")
+        .firstName("Jane")
+        .lastName("Smith")
+        .build();
+
+    Book book = Book.builder()
+        .id("book123")
+        .title("Test Book")
+        .author("Test Author")
+        .condition(Condition.GOOD)
+        .coverPhotos(List.of("cover-photo-id-123"))
+        .build();
+
+    SwapRequest swapRequest = SwapRequest.builder()
+        .id("swap1")
+        .sender(sender)
+        .receiver(receiver)
+        .bookToSwapWith(book)
+        .swapType(SwapType.BY_BOOKS)
+        .swapStatus(SwapStatus.PENDING)
+        .requestedAt(Instant.parse("2025-01-01T10:00:00Z"))
+        .updatedAt(Instant.parse("2025-01-01T10:00:00Z"))
+        .askForGiveaway(false)
+        .build();
+
+    when(inboxService.getUnifiedInbox("receiver123", null, null)).thenReturn(List.of(swapRequest));
+    when(inboxService.getUnreadMessageCount("receiver123", "swap1")).thenReturn(0L);
+    when(inboxService.isInboxItemUnread(swapRequest, "receiver123")).thenReturn(false);
+    when(photoService.getBookCoverPhoto("cover-photo-id-123"))
+        .thenReturn("https://minio.example.com/presigned-url");
+
+    mockMvc.perform(get(API_PATH)
+        .with(withUser("receiver123")))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].bookToSwapWith.coverPhotoUrl")
+            .value("https://minio.example.com/presigned-url"));
+
+    verify(photoService).getBookCoverPhoto("cover-photo-id-123");
+  }
+
+  @Test
+  @DisplayName("Should fallback to null when cover photo resolution fails")
+  void shouldFallbackToNullWhenCoverPhotoResolutionFails() throws Exception {
+    User sender = User.builder()
+        .id("sender123")
+        .firstName("John")
+        .lastName("Doe")
+        .build();
+
+    User receiver = User.builder()
+        .id("receiver123")
+        .firstName("Jane")
+        .lastName("Smith")
+        .build();
+
+    Book book = Book.builder()
+        .id("book123")
+        .title("Test Book")
+        .author("Test Author")
+        .condition(Condition.GOOD)
+        .coverPhotos(List.of("missing-photo-id"))
+        .build();
+
+    SwapRequest swapRequest = SwapRequest.builder()
+        .id("swap1")
+        .sender(sender)
+        .receiver(receiver)
+        .bookToSwapWith(book)
+        .swapType(SwapType.BY_BOOKS)
+        .swapStatus(SwapStatus.PENDING)
+        .requestedAt(Instant.parse("2025-01-01T10:00:00Z"))
+        .updatedAt(Instant.parse("2025-01-01T10:00:00Z"))
+        .askForGiveaway(false)
+        .build();
+
+    when(inboxService.getUnifiedInbox("receiver123", null, null)).thenReturn(List.of(swapRequest));
+    when(inboxService.getUnreadMessageCount("receiver123", "swap1")).thenReturn(0L);
+    when(inboxService.isInboxItemUnread(swapRequest, "receiver123")).thenReturn(false);
+    when(photoService.getBookCoverPhoto("missing-photo-id"))
+        .thenThrow(new PhotoNotFoundException());
+
+    mockMvc.perform(get(API_PATH)
+        .with(withUser("receiver123")))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].bookToSwapWith.coverPhotoUrl").doesNotExist());
+
+    verify(photoService).getBookCoverPhoto("missing-photo-id");
   }
 
   private static RequestPostProcessor withUser(String userId) {

--- a/src/test/java/com/kirjaswappi/backend/integration/InboxApiIntegrationTest.java
+++ b/src/test/java/com/kirjaswappi/backend/integration/InboxApiIntegrationTest.java
@@ -25,6 +25,7 @@ import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import com.kirjaswappi.backend.common.http.controllers.mockMvc.config.CustomMockMvcConfiguration;
 import com.kirjaswappi.backend.http.controllers.InboxController;
 import com.kirjaswappi.backend.service.InboxService;
+import com.kirjaswappi.backend.service.PhotoService;
 import com.kirjaswappi.backend.service.entities.*;
 import com.kirjaswappi.backend.service.enums.*;
 import com.kirjaswappi.backend.service.exceptions.BadRequestException;
@@ -44,6 +45,9 @@ class InboxApiIntegrationTest {
 
   @MockitoBean
   private InboxService inboxService;
+
+  @MockitoBean
+  private PhotoService photoService;
 
   private SwapRequest createTestSwapRequest(String id, String senderId, String receiverId, SwapStatus status) {
     User sender = User.builder()


### PR DESCRIPTION
## Summary
- The inbox API was returning raw MinIO object IDs for book cover photos instead of presigned download URLs, causing broken images in the frontend chat list and chat view
- Added `PhotoService` to `InboxController` to resolve cover photo IDs to presigned URLs via `getBookCoverPhoto()`, matching the pattern already used in `BookService`
- Added delegate methods on `InboxItemResponse` to access the inner `BookSummaryResponse.coverPhotoUrl` field
- Added `PhotoService` mock bean to `InboxControllerTest` for Spring context loading

## Test plan
- [ ] Verify inbox API response now returns valid presigned URLs for `bookToSwapWith.coverPhotoUrl`
- [ ] Verify book cover images render correctly in chat list (left panel)
- [ ] Verify book cover images render correctly in individual chat view (top bar)
- [ ] Verify graceful fallback when cover photo is missing (null returned, frontend shows placeholder)