### PR TITLE
Fix: v1 release readiness audit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,11 @@
 			<artifactId>spring-boot-starter-webmvc-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 
 		<!-- Unleash -->
 		<dependency>

--- a/src/main/java/com/kirjaswappi/backend/common/configs/CloudSecurityConfig.java
+++ b/src/main/java/com/kirjaswappi/backend/common/configs/CloudSecurityConfig.java
@@ -56,7 +56,7 @@ public class CloudSecurityConfig {
     return http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .csrf(csrf -> csrf.disable()) // Disable CSRF protection
         .authorizeHttpRequests(authorize -> authorize
-            .requestMatchers(HEALTH, API_DOCS, SWAGGER_UI, API_BASE + AUTHENTICATE,
+            .requestMatchers(HEALTH, API_BASE + AUTHENTICATE,
                 API_BASE + AUTHENTICATE + REFRESH, "/ws/**")
             .permitAll()
             // User auth endpoints (no JWT required)
@@ -74,6 +74,7 @@ public class CloudSecurityConfig {
             .requestMatchers(DELETE, API_BASE + ADMIN_USERS + USERNAME).hasAuthority(ADMIN)
             .requestMatchers(DELETE, API_BASE + SWAP_REQUESTS).hasAuthority(ADMIN)
             .requestMatchers(DELETE, API_BASE + BOOKS).hasAuthority(ADMIN)
+            .requestMatchers(API_DOCS, SWAGGER_UI).hasAuthority(ADMIN)
             .anyRequest().hasAnyAuthority(ADMIN, USER))
         .addFilterBefore(filterApiRequest, UsernamePasswordAuthenticationFilter.class)
         .cors(cors -> cors.configurationSource(corsConfigurationSource()))

--- a/src/main/java/com/kirjaswappi/backend/common/configs/RedisCacheConfig.java
+++ b/src/main/java/com/kirjaswappi/backend/common/configs/RedisCacheConfig.java
@@ -67,7 +67,7 @@ public class RedisCacheConfig {
         .withCacheConfiguration("nested_genres", config.entryTtl(Duration.ofDays(7))
             .serializeValuesWith(RedisSerializationContext.SerializationPair
                 .fromSerializer(new Jackson2JsonRedisSerializer<>(objectMapper, NestedGenresResponse.class))))
-        .withCacheConfiguration("imageUrls", config.entryTtl(Duration.ofDays(7))
+        .withCacheConfiguration("imageUrls", config.entryTtl(Duration.ofDays(6))
             .serializeValuesWith(RedisSerializationContext.SerializationPair
                 .fromSerializer(new Jackson2JsonRedisSerializer<>(objectMapper, String.class))))
         .build();

--- a/src/main/java/com/kirjaswappi/backend/common/configs/WebSocketConfig.java
+++ b/src/main/java/com/kirjaswappi/backend/common/configs/WebSocketConfig.java
@@ -60,7 +60,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     config.setUserDestinationPrefix("/user");
   }
 
-  @org.springframework.beans.factory.annotation.Value("${FRONTEND_URL:*}")
+  @org.springframework.beans.factory.annotation.Value("${FRONTEND_URL:http://localhost:5173}")
   private String[] allowedOriginPatterns;
 
   @Override

--- a/src/main/java/com/kirjaswappi/backend/common/http/GlobalExceptionHandler.java
+++ b/src/main/java/com/kirjaswappi/backend/common/http/GlobalExceptionHandler.java
@@ -58,9 +58,21 @@ public class GlobalExceptionHandler {
     return errorUtils.buildErrorResponse(exception, webRequest);
   }
 
+  @ExceptionHandler(BookNotFoundException.class)
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  public ErrorResponse handleBookNotFoundException(BookNotFoundException exception, WebRequest webRequest) {
+    return errorUtils.buildErrorResponse(exception, webRequest);
+  }
+
   @ExceptionHandler(ChatAccessDeniedException.class)
   @ResponseStatus(HttpStatus.FORBIDDEN)
   public ErrorResponse handleChatAccessDeniedException(ChatAccessDeniedException exception, WebRequest webRequest) {
+    return errorUtils.buildErrorResponse(exception, webRequest);
+  }
+
+  @ExceptionHandler(AccessDeniedException.class)
+  @ResponseStatus(HttpStatus.FORBIDDEN)
+  public ErrorResponse handleAccessDeniedException(AccessDeniedException exception, WebRequest webRequest) {
     return errorUtils.buildErrorResponse(exception, webRequest);
   }
 
@@ -128,5 +140,12 @@ public class GlobalExceptionHandler {
     ex.getBindingResult().getFieldErrors().forEach(fieldError -> error.addErrorDetail(
         "invalidField", fieldError.getDefaultMessage(), fieldError.getField()));
     return new ErrorResponse(error);
+  }
+
+  @ExceptionHandler(IllegalArgumentException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ErrorResponse handleIllegalArgumentException(IllegalArgumentException ex) {
+    log.warn("Invalid argument: {}", ex.getMessage());
+    return new ErrorResponse(new ErrorResponse.Error("invalidArgument", ex.getMessage()));
   }
 }

--- a/src/main/java/com/kirjaswappi/backend/common/http/GlobalExceptionHandler.java
+++ b/src/main/java/com/kirjaswappi/backend/common/http/GlobalExceptionHandler.java
@@ -146,6 +146,6 @@ public class GlobalExceptionHandler {
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   public ErrorResponse handleIllegalArgumentException(IllegalArgumentException ex) {
     log.warn("Invalid argument: {}", ex.getMessage());
-    return new ErrorResponse(new ErrorResponse.Error("invalidArgument", ex.getMessage()));
+    return new ErrorResponse(new ErrorResponse.Error("invalidArgument", "Invalid request argument"));
   }
 }

--- a/src/main/java/com/kirjaswappi/backend/common/http/controllers/OTPController.java
+++ b/src/main/java/com/kirjaswappi/backend/common/http/controllers/OTPController.java
@@ -27,6 +27,7 @@ import com.kirjaswappi.backend.common.http.dtos.requests.VerifyOtpRequest;
 import com.kirjaswappi.backend.common.http.dtos.responses.SendOtpResponse;
 import com.kirjaswappi.backend.common.http.dtos.responses.VerifyOtpResponse;
 import com.kirjaswappi.backend.common.service.OTPService;
+import com.kirjaswappi.backend.common.utils.JwtUtil;
 
 @RestController
 @RequestMapping(API_BASE)
@@ -34,6 +35,9 @@ import com.kirjaswappi.backend.common.service.OTPService;
 public class OTPController {
   @Autowired
   private OTPService otpService;
+
+  @Autowired
+  private JwtUtil jwtUtil;
 
   @PostMapping(SEND_OTP)
   @Operation(summary = "Send OTP to user email", description = "Generates and sends a one-time password (OTP) to the specified email address.", responses = {
@@ -54,6 +58,7 @@ public class OTPController {
   })
   public ResponseEntity<VerifyOtpResponse> verifyOTP(@RequestBody VerifyOtpRequest request) {
     String email = otpService.verifyOTPByEmail(request.toEntity());
-    return ResponseEntity.status(HttpStatus.OK).body(new VerifyOtpResponse(email));
+    String resetToken = jwtUtil.generatePasswordResetToken(email);
+    return ResponseEntity.status(HttpStatus.OK).body(new VerifyOtpResponse(email, resetToken));
   }
 }

--- a/src/main/java/com/kirjaswappi/backend/common/http/dtos/responses/VerifyOtpResponse.java
+++ b/src/main/java/com/kirjaswappi/backend/common/http/dtos/responses/VerifyOtpResponse.java
@@ -15,7 +15,15 @@ public class VerifyOtpResponse {
   @Schema(description = "Confirmation message indicating OTP was verified", example = "OTP verified for user@example.com successfully.")
   private String message;
 
+  @Schema(description = "Short-lived token required for password reset", example = "eyJhbGciOiJIUzI1NiJ9...")
+  private String resetToken;
+
   public VerifyOtpResponse(String email) {
     this.message = "OTP verified for " + email + " successfully.";
+  }
+
+  public VerifyOtpResponse(String email, String resetToken) {
+    this.message = "OTP verified for " + email + " successfully.";
+    this.resetToken = resetToken;
   }
 }

--- a/src/main/java/com/kirjaswappi/backend/common/service/OTPService.java
+++ b/src/main/java/com/kirjaswappi/backend/common/service/OTPService.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.concurrent.ConcurrentHashMap;
 
 import lombok.RequiredArgsConstructor;
 
@@ -36,46 +35,14 @@ public class OTPService {
 
   private final EmailService emailService;
 
+  private final RateLimiterService rateLimiterService;
+
   private static final SecureRandom SECURE_RANDOM = new SecureRandom();
   private static final int MAX_VERIFY_ATTEMPTS = 5;
   private static final int MAX_SEND_ATTEMPTS = 5;
   private static final Duration RATE_LIMIT_WINDOW = Duration.ofMinutes(15);
-
-  private final ConcurrentHashMap<String, RateLimitEntry> verifyAttempts = new ConcurrentHashMap<>();
-  private final ConcurrentHashMap<String, RateLimitEntry> sendAttempts = new ConcurrentHashMap<>();
-
-  private record RateLimitEntry(
-      int count,
-      Instant windowStart
-  ) {
-  }
-
-  private boolean isRateLimited(ConcurrentHashMap<String, RateLimitEntry> attempts, String key, int maxAttempts) {
-    var now = Instant.now();
-    var entry = attempts.get(key);
-    if (entry == null) {
-      return false;
-    }
-    if (entry.windowStart().plus(RATE_LIMIT_WINDOW).isBefore(now)) {
-      attempts.remove(key);
-      return false;
-    }
-    return entry.count() >= maxAttempts;
-  }
-
-  private void recordFailedAttempt(ConcurrentHashMap<String, RateLimitEntry> attempts, String key) {
-    var now = Instant.now();
-    attempts.compute(key, (k, existing) -> {
-      if (existing == null || existing.windowStart().plus(RATE_LIMIT_WINDOW).isBefore(now)) {
-        return new RateLimitEntry(1, now);
-      }
-      return new RateLimitEntry(existing.count() + 1, existing.windowStart());
-    });
-  }
-
-  private void clearAttempts(ConcurrentHashMap<String, RateLimitEntry> attempts, String key) {
-    attempts.remove(key);
-  }
+  private static final String VERIFY_RATE_LIMIT_PREFIX = "ratelimit:otp-verify:";
+  private static final String SEND_RATE_LIMIT_PREFIX = "ratelimit:otp-send:";
 
   private static String generateOTP() {
     return SECURE_RANDOM.ints(6, 0, NUMERIC.length())
@@ -94,8 +61,10 @@ public class OTPService {
       throw new BadRequestException("emailCannotBeNull");
     }
 
+    String rateLimitKey = VERIFY_RATE_LIMIT_PREFIX + otp.email();
+
     // Rate limit OTP verification attempts
-    if (isRateLimited(verifyAttempts, otp.email(), MAX_VERIFY_ATTEMPTS)) {
+    if (rateLimiterService.isRateLimited(rateLimitKey, MAX_VERIFY_ATTEMPTS)) {
       throw new BadRequestException("tooManyVerifyAttempts", otp.email());
     }
 
@@ -103,19 +72,19 @@ public class OTPService {
 
     // check provided OTP with the stored OTP:
     if (!otpEntity.otp().equals(otp.otp())) {
-      recordFailedAttempt(verifyAttempts, otp.email());
+      rateLimiterService.recordAttempt(rateLimitKey, RATE_LIMIT_WINDOW);
       throw new BadRequestException("otpDoesNotMatch", otp);
     }
 
     // Check if the OTP is older than 15 minutes
     if (otpEntity.createdAt().plus(Duration.ofMinutes(15)).isBefore(Instant.now())) {
-      recordFailedAttempt(verifyAttempts, otp.email());
+      rateLimiterService.recordAttempt(rateLimitKey, RATE_LIMIT_WINDOW);
       throw new BadRequestException("otpExpired", otp);
     }
 
     // Delete the OTP after verification:
     otpRepository.deleteAllByEmail(otp.email());
-    clearAttempts(verifyAttempts, otp.email());
+    rateLimiterService.clearAttempts(rateLimitKey);
     return otpEntity.email();
   }
 
@@ -128,14 +97,16 @@ public class OTPService {
       throw new BadRequestException("emailCannotBeNull");
     }
 
+    String rateLimitKey = SEND_RATE_LIMIT_PREFIX + email;
+
     // Rate limit OTP send attempts
-    if (isRateLimited(sendAttempts, email, MAX_SEND_ATTEMPTS)) {
+    if (rateLimiterService.isRateLimited(rateLimitKey, MAX_SEND_ATTEMPTS)) {
       throw new BadRequestException("tooManySendOtpAttempts", email);
     }
 
     // Check if the user exists:
     if (!checkUserExists(email)) {
-      recordFailedAttempt(sendAttempts, email);
+      rateLimiterService.recordAttempt(rateLimitKey, RATE_LIMIT_WINDOW);
       throw new UserNotFoundException(email);
     }
 
@@ -151,7 +122,7 @@ public class OTPService {
 
     // Send OTP via email:
     emailService.sendOTPByEmail(dao.email(), newOTP.otp());
-    clearAttempts(sendAttempts, email);
+    rateLimiterService.clearAttempts(rateLimitKey);
     return dao.email();
   }
 }

--- a/src/main/java/com/kirjaswappi/backend/common/service/OTPService.java
+++ b/src/main/java/com/kirjaswappi/backend/common/service/OTPService.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
 
 import lombok.RequiredArgsConstructor;
 
@@ -36,6 +37,29 @@ public class OTPService {
   private final EmailService emailService;
 
   private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+  private static final int MAX_VERIFY_ATTEMPTS = 5;
+  private static final int MAX_SEND_ATTEMPTS = 5;
+  private static final Duration RATE_LIMIT_WINDOW = Duration.ofMinutes(15);
+
+  private final ConcurrentHashMap<String, RateLimitEntry> verifyAttempts = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, RateLimitEntry> sendAttempts = new ConcurrentHashMap<>();
+
+  private record RateLimitEntry(
+      int count,
+      Instant windowStart
+  ) {
+  }
+
+  private boolean isRateLimited(ConcurrentHashMap<String, RateLimitEntry> attempts, String key, int maxAttempts) {
+    var now = Instant.now();
+    var entry = attempts.compute(key, (k, existing) -> {
+      if (existing == null || existing.windowStart().plus(RATE_LIMIT_WINDOW).isBefore(now)) {
+        return new RateLimitEntry(1, now);
+      }
+      return new RateLimitEntry(existing.count() + 1, existing.windowStart());
+    });
+    return entry.count() > maxAttempts;
+  }
 
   private static String generateOTP() {
     return SECURE_RANDOM.ints(6, 0, NUMERIC.length())
@@ -50,6 +74,11 @@ public class OTPService {
   }
 
   public String verifyOTPByEmail(OTP otp) {
+    // Rate limit OTP verification attempts
+    if (isRateLimited(verifyAttempts, otp.email(), MAX_VERIFY_ATTEMPTS)) {
+      throw new BadRequestException("tooManyVerifyAttempts", otp.email());
+    }
+
     var otpEntity = this.getOTP(otp.email());
 
     // check provided OTP with the stored OTP:
@@ -72,6 +101,11 @@ public class OTPService {
   }
 
   public String saveAndSendOTP(String email) throws IOException {
+    // Rate limit OTP send attempts
+    if (isRateLimited(sendAttempts, email, MAX_SEND_ATTEMPTS)) {
+      throw new BadRequestException("tooManySendOtpAttempts", email);
+    }
+
     // Check if the user exists:
     if (!checkUserExists(email)) {
       throw new UserNotFoundException(email);

--- a/src/main/java/com/kirjaswappi/backend/common/service/OTPService.java
+++ b/src/main/java/com/kirjaswappi/backend/common/service/OTPService.java
@@ -52,13 +52,29 @@ public class OTPService {
 
   private boolean isRateLimited(ConcurrentHashMap<String, RateLimitEntry> attempts, String key, int maxAttempts) {
     var now = Instant.now();
-    var entry = attempts.compute(key, (k, existing) -> {
+    var entry = attempts.get(key);
+    if (entry == null) {
+      return false;
+    }
+    if (entry.windowStart().plus(RATE_LIMIT_WINDOW).isBefore(now)) {
+      attempts.remove(key);
+      return false;
+    }
+    return entry.count() > maxAttempts;
+  }
+
+  private void recordFailedAttempt(ConcurrentHashMap<String, RateLimitEntry> attempts, String key) {
+    var now = Instant.now();
+    attempts.compute(key, (k, existing) -> {
       if (existing == null || existing.windowStart().plus(RATE_LIMIT_WINDOW).isBefore(now)) {
         return new RateLimitEntry(1, now);
       }
       return new RateLimitEntry(existing.count() + 1, existing.windowStart());
     });
-    return entry.count() > maxAttempts;
+  }
+
+  private void clearAttempts(ConcurrentHashMap<String, RateLimitEntry> attempts, String key) {
+    attempts.remove(key);
   }
 
   private static String generateOTP() {
@@ -87,16 +103,19 @@ public class OTPService {
 
     // check provided OTP with the stored OTP:
     if (!otpEntity.otp().equals(otp.otp())) {
+      recordFailedAttempt(verifyAttempts, otp.email());
       throw new BadRequestException("otpDoesNotMatch", otp);
     }
 
     // Check if the OTP is older than 15 minutes
     if (otpEntity.createdAt().plus(Duration.ofMinutes(15)).isBefore(Instant.now())) {
+      recordFailedAttempt(verifyAttempts, otp.email());
       throw new BadRequestException("otpExpired", otp);
     }
 
     // Delete the OTP after verification:
     otpRepository.deleteAllByEmail(otp.email());
+    clearAttempts(verifyAttempts, otp.email());
     return otpEntity.email();
   }
 
@@ -116,6 +135,7 @@ public class OTPService {
 
     // Check if the user exists:
     if (!checkUserExists(email)) {
+      recordFailedAttempt(sendAttempts, email);
       throw new UserNotFoundException(email);
     }
 
@@ -131,6 +151,7 @@ public class OTPService {
 
     // Send OTP via email:
     emailService.sendOTPByEmail(dao.email(), newOTP.otp());
+    clearAttempts(sendAttempts, email);
     return dao.email();
   }
 }

--- a/src/main/java/com/kirjaswappi/backend/common/service/OTPService.java
+++ b/src/main/java/com/kirjaswappi/backend/common/service/OTPService.java
@@ -74,6 +74,10 @@ public class OTPService {
   }
 
   public String verifyOTPByEmail(OTP otp) {
+    if (otp.email() == null) {
+      throw new ResourceNotFoundException("otpNotFound", (Object) null);
+    }
+
     // Rate limit OTP verification attempts
     if (isRateLimited(verifyAttempts, otp.email(), MAX_VERIFY_ATTEMPTS)) {
       throw new BadRequestException("tooManyVerifyAttempts", otp.email());
@@ -101,6 +105,10 @@ public class OTPService {
   }
 
   public String saveAndSendOTP(String email) throws IOException {
+    if (email == null) {
+      throw new UserNotFoundException();
+    }
+
     // Rate limit OTP send attempts
     if (isRateLimited(sendAttempts, email, MAX_SEND_ATTEMPTS)) {
       throw new BadRequestException("tooManySendOtpAttempts", email);

--- a/src/main/java/com/kirjaswappi/backend/common/service/OTPService.java
+++ b/src/main/java/com/kirjaswappi/backend/common/service/OTPService.java
@@ -99,14 +99,16 @@ public class OTPService {
 
     String rateLimitKey = SEND_RATE_LIMIT_PREFIX + email;
 
-    // Rate limit OTP send attempts
+    // Rate limit OTP send attempts (applied regardless of user existence)
     if (rateLimiterService.isRateLimited(rateLimitKey, MAX_SEND_ATTEMPTS)) {
       throw new BadRequestException("tooManySendOtpAttempts", email);
     }
 
+    // Record the attempt before checking user existence to prevent enumeration
+    rateLimiterService.recordAttempt(rateLimitKey, RATE_LIMIT_WINDOW);
+
     // Check if the user exists:
     if (!checkUserExists(email)) {
-      rateLimiterService.recordAttempt(rateLimitKey, RATE_LIMIT_WINDOW);
       throw new UserNotFoundException(email);
     }
 
@@ -122,7 +124,6 @@ public class OTPService {
 
     // Send OTP via email:
     emailService.sendOTPByEmail(dao.email(), newOTP.otp());
-    rateLimiterService.clearAttempts(rateLimitKey);
     return dao.email();
   }
 }

--- a/src/main/java/com/kirjaswappi/backend/common/service/OTPService.java
+++ b/src/main/java/com/kirjaswappi/backend/common/service/OTPService.java
@@ -106,7 +106,7 @@ public class OTPService {
 
   public String saveAndSendOTP(String email) throws IOException {
     if (email == null) {
-      throw new UserNotFoundException();
+      throw new BadRequestException("emailCannotBeNull");
     }
 
     // Rate limit OTP send attempts

--- a/src/main/java/com/kirjaswappi/backend/common/service/OTPService.java
+++ b/src/main/java/com/kirjaswappi/backend/common/service/OTPService.java
@@ -60,7 +60,7 @@ public class OTPService {
       attempts.remove(key);
       return false;
     }
-    return entry.count() > maxAttempts;
+    return entry.count() >= maxAttempts;
   }
 
   private void recordFailedAttempt(ConcurrentHashMap<String, RateLimitEntry> attempts, String key) {
@@ -91,7 +91,7 @@ public class OTPService {
 
   public String verifyOTPByEmail(OTP otp) {
     if (otp.email() == null) {
-      throw new ResourceNotFoundException("otpNotFound", (Object) null);
+      throw new BadRequestException("emailCannotBeNull");
     }
 
     // Rate limit OTP verification attempts

--- a/src/main/java/com/kirjaswappi/backend/common/service/ProfanityFilterService.java
+++ b/src/main/java/com/kirjaswappi/backend/common/service/ProfanityFilterService.java
@@ -4,40 +4,37 @@
  */
 package com.kirjaswappi.backend.common.service;
 
+import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.springframework.stereotype.Service;
 
-/**
- * Simple service to filter explicit or dangerous words from text. This is a
- * basic implementation that can be expanded with more comprehensive lists.
- */
 @Service
 public class ProfanityFilterService {
 
-  // Common profanity words to filter in a book exchange context
   private static final Set<String> BANNED_WORDS = Set.of(
       "fuck", "shit", "asshole", "bitch", "bastard",
       "dick", "cunt", "damn", "piss", "slut",
       "whore", "nigger", "faggot", "retard", "twat",
       "wanker", "bollocks", "motherfucker", "cocksucker", "arse");
 
-  /**
-   * Replaces banned words in the given text with asterisks.
-   *
-   * @param text The text to filter
-   * @return The filtered text
-   */
+  private static final List<Pattern> BANNED_PATTERNS;
+
+  static {
+    BANNED_PATTERNS = BANNED_WORDS.stream()
+        .map(word -> Pattern.compile("\\b" + Pattern.quote(word) + "\\b", Pattern.CASE_INSENSITIVE))
+        .toList();
+  }
+
   public String filter(String text) {
     if (text == null) {
       return null;
     }
 
     String filtered = text;
-    for (String word : BANNED_WORDS) {
-      // Case-insensitive replacement
-      filtered = filtered.replaceAll("(?i)" + Pattern.quote(word), "***");
+    for (Pattern pattern : BANNED_PATTERNS) {
+      filtered = pattern.matcher(filtered).replaceAll("***");
     }
     return filtered;
   }

--- a/src/main/java/com/kirjaswappi/backend/common/service/ProfanityFilterService.java
+++ b/src/main/java/com/kirjaswappi/backend/common/service/ProfanityFilterService.java
@@ -16,9 +16,12 @@ import org.springframework.stereotype.Service;
 @Service
 public class ProfanityFilterService {
 
-  // Placeholder list of words to filter.
+  // Common profanity words to filter in a book exchange context
   private static final Set<String> BANNED_WORDS = Set.of(
-      "badword1", "badword2", "dangerousword");
+      "fuck", "shit", "asshole", "bitch", "bastard",
+      "dick", "cunt", "damn", "piss", "slut",
+      "whore", "nigger", "faggot", "retard", "twat",
+      "wanker", "bollocks", "motherfucker", "cocksucker", "arse");
 
   /**
    * Replaces banned words in the given text with asterisks.

--- a/src/main/java/com/kirjaswappi/backend/common/service/RateLimiterService.java
+++ b/src/main/java/com/kirjaswappi/backend/common/service/RateLimiterService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 KirjaSwappi or KirjaSwappi affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+package com.kirjaswappi.backend.common.service;
+
+import java.time.Duration;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RateLimiterService {
+
+  private final StringRedisTemplate redisTemplate;
+
+  public boolean isRateLimited(String key, int maxAttempts) {
+    try {
+      String value = redisTemplate.opsForValue().get(key);
+      if (value == null) {
+        return false;
+      }
+      return Integer.parseInt(value) >= maxAttempts;
+    } catch (Exception e) {
+      log.warn("Redis unavailable for rate limit check, allowing request: {}", e.getMessage());
+      return false;
+    }
+  }
+
+  public void recordAttempt(String key, Duration window) {
+    try {
+      Long count = redisTemplate.opsForValue().increment(key);
+      if (count != null && count == 1) {
+        redisTemplate.expire(key, window);
+      }
+    } catch (Exception e) {
+      log.warn("Redis unavailable for recording rate limit attempt: {}", e.getMessage());
+    }
+  }
+
+  public void clearAttempts(String key) {
+    try {
+      redisTemplate.delete(key);
+    } catch (Exception e) {
+      log.warn("Redis unavailable for clearing rate limit attempts: {}", e.getMessage());
+    }
+  }
+}

--- a/src/main/java/com/kirjaswappi/backend/common/service/RateLimiterService.java
+++ b/src/main/java/com/kirjaswappi/backend/common/service/RateLimiterService.java
@@ -34,10 +34,9 @@ public class RateLimiterService {
 
   public void recordAttempt(String key, Duration window) {
     try {
-      Long count = redisTemplate.opsForValue().increment(key);
-      if (count != null && count == 1) {
-        redisTemplate.expire(key, window);
-      }
+      redisTemplate.opsForValue().increment(key);
+      // Always set expiry to ensure TTL is present even if a prior set failed
+      redisTemplate.expire(key, window);
     } catch (Exception e) {
       log.warn("Redis unavailable for recording rate limit attempt: {}", e.getMessage());
     }

--- a/src/main/java/com/kirjaswappi/backend/common/utils/JwtUtil.java
+++ b/src/main/java/com/kirjaswappi/backend/common/utils/JwtUtil.java
@@ -196,4 +196,34 @@ public class JwtUtil {
   public String extractUserId(String token) {
     return extractClaim(token, Claims::getSubject);
   }
+
+  // =========== Password Reset Token Methods ===========
+
+  private static final String RESET_TOKEN_PURPOSE = "passwordReset";
+  private static final long RESET_TOKEN_EXPIRATION_MS = 900000; // 15 minutes
+
+  public String generatePasswordResetToken(String email) {
+    Map<String, Object> claims = new HashMap<>();
+    claims.put(TOKEN_PURPOSE, RESET_TOKEN_PURPOSE);
+    return Jwts.builder()
+        .claims(claims)
+        .subject(email)
+        .issuedAt(new Date(System.currentTimeMillis()))
+        .expiration(new Date(System.currentTimeMillis() + RESET_TOKEN_EXPIRATION_MS))
+        .signWith(SECRET_KEY)
+        .compact();
+  }
+
+  public boolean validatePasswordResetToken(String token) {
+    try {
+      Claims claims = extractAllClaims(token);
+      return RESET_TOKEN_PURPOSE.equals(claims.get(TOKEN_PURPOSE)) && isTokenValid(token);
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  public String extractEmailFromResetToken(String token) {
+    return extractClaim(token, Claims::getSubject);
+  }
 }

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/BookController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/BookController.java
@@ -134,6 +134,12 @@ public class BookController {
         || filter.getEast() == null || filter.getWest() == null) {
       throw new BadRequestException("allMapBoundsRequired");
     }
+    if (filter.getNorth() < filter.getSouth()) {
+      throw new BadRequestException("invalidMapBounds", "north must be >= south");
+    }
+    if (filter.getEast() < filter.getWest()) {
+      throw new BadRequestException("invalidMapBounds", "east must be >= west");
+    }
     Page<Book> books = bookService.getAllBooksByFilter(filter, pageable);
     Page<BookListResponse> response = books.map(BookListResponse::new);
     return ResponseEntity.status(HttpStatus.OK).body(LinkBuilder.forPage(response, API_BASE + BOOKS + "/map"));

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/BookController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/BookController.java
@@ -125,10 +125,15 @@ public class BookController {
 
   @GetMapping("/map")
   @Operation(summary = "Find books within map bounding box.", responses = {
-      @ApiResponse(responseCode = "200", description = "List of books within the map bounds.") })
+      @ApiResponse(responseCode = "200", description = "List of books within the map bounds."),
+      @ApiResponse(responseCode = "400", description = "Missing required map bounds.") })
   public ResponseEntity<PagedModel<BookListResponse>> findBooksInMapBounds(
       @Valid @ParameterObject FindAllBooksFilter filter,
       @PageableDefault(size = 100) Pageable pageable) {
+    if (filter.getNorth() == null || filter.getSouth() == null
+        || filter.getEast() == null || filter.getWest() == null) {
+      throw new BadRequestException("allMapBoundsRequired");
+    }
     Page<Book> books = bookService.getAllBooksByFilter(filter, pageable);
     Page<BookListResponse> response = books.map(BookListResponse::new);
     return ResponseEntity.status(HttpStatus.OK).body(LinkBuilder.forPage(response, API_BASE + BOOKS + "/map"));
@@ -228,7 +233,11 @@ public class BookController {
   }
 
   private void verifyBookOwnership(String bookId) {
-    String authenticatedUserId = SecurityContextHolder.getContext().getAuthentication().getName();
+    var authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication == null) {
+      throw new AccessDeniedException("notBookOwner", bookId);
+    }
+    String authenticatedUserId = authentication.getName();
     Book book = bookService.getBookById(bookId);
     if (book.owner() == null || !authenticatedUserId.equals(book.owner().id())) {
       throw new AccessDeniedException("notBookOwner", bookId);

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/BookController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/BookController.java
@@ -23,6 +23,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -46,6 +47,7 @@ import com.kirjaswappi.backend.service.entities.Book;
 import com.kirjaswappi.backend.service.enums.Condition;
 import com.kirjaswappi.backend.service.enums.Language;
 import com.kirjaswappi.backend.service.enums.SwapType;
+import com.kirjaswappi.backend.service.exceptions.AccessDeniedException;
 import com.kirjaswappi.backend.service.exceptions.BadRequestException;
 import com.kirjaswappi.backend.service.filters.FindAllBooksFilter;
 
@@ -56,6 +58,8 @@ import com.kirjaswappi.backend.service.filters.FindAllBooksFilter;
 public class BookController {
   @Autowired
   private BookService bookService;
+
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
   @PostMapping(consumes = "multipart/form-data")
   @Operation(summary = "Add book to a user.", responses = {
@@ -119,6 +123,17 @@ public class BookController {
     return ResponseEntity.status(HttpStatus.OK).body(LinkBuilder.forPage(response, API_BASE + BOOKS));
   }
 
+  @GetMapping("/map")
+  @Operation(summary = "Find books within map bounding box.", responses = {
+      @ApiResponse(responseCode = "200", description = "List of books within the map bounds.") })
+  public ResponseEntity<PagedModel<BookListResponse>> findBooksInMapBounds(
+      @Valid @ParameterObject FindAllBooksFilter filter,
+      @PageableDefault(size = 100) Pageable pageable) {
+    Page<Book> books = bookService.getAllBooksByFilter(filter, pageable);
+    Page<BookListResponse> response = books.map(BookListResponse::new);
+    return ResponseEntity.status(HttpStatus.OK).body(LinkBuilder.forPage(response, API_BASE + BOOKS + "/map"));
+  }
+
   @GetMapping("/near")
   @Operation(summary = "Find books near a specific location within a given radius.", responses = {
       @ApiResponse(responseCode = "200", description = "List of Books near the specified location."),
@@ -175,6 +190,7 @@ public class BookController {
   @Operation(summary = "Update book by Book ID.", responses = {
       @ApiResponse(responseCode = "200", description = "Book updated."),
       @ApiResponse(responseCode = "400", description = "Invalid request or ID mismatch."),
+      @ApiResponse(responseCode = "403", description = "Not the book owner."),
       @ApiResponse(responseCode = "404", description = "Book not found.") })
   public ResponseEntity<BookResponse> updateBook(@Parameter(description = "Book ID.") @PathVariable String id,
       @Valid @ModelAttribute UpdateBookRequest request) {
@@ -182,6 +198,8 @@ public class BookController {
     if (!id.equals(request.getId())) {
       throw new BadRequestException("idMismatch", id, request.getId());
     }
+    // verify ownership:
+    verifyBookOwnership(id);
     Book entity = request.toEntity();
     entity = this.parseBookSwapCondition(request.getSwapCondition(), entity);
     entity = this.parseBookLocation(request.getLocation(), entity);
@@ -192,8 +210,11 @@ public class BookController {
   @DeleteMapping(ID)
   @Operation(summary = "Delete book by Book ID.", responses = {
       @ApiResponse(responseCode = "204", description = "Book deleted."),
+      @ApiResponse(responseCode = "403", description = "Not the book owner."),
       @ApiResponse(responseCode = "404", description = "Book not found.") })
   public ResponseEntity<Void> deleteBook(@Parameter(description = "Book ID.") @PathVariable String id) {
+    // verify ownership:
+    verifyBookOwnership(id);
     bookService.deleteBook(id);
     return ResponseEntity.noContent().build();
   }
@@ -206,8 +227,15 @@ public class BookController {
     return ResponseEntity.noContent().build();
   }
 
+  private void verifyBookOwnership(String bookId) {
+    String authenticatedUserId = SecurityContextHolder.getContext().getAuthentication().getName();
+    Book book = bookService.getBookById(bookId);
+    if (book.owner() == null || !authenticatedUserId.equals(book.owner().id())) {
+      throw new AccessDeniedException("notBookOwner", bookId);
+    }
+  }
+
   private Book parseBookSwapCondition(String swapConditionJson, Book book) {
-    var objectMapper = new ObjectMapper();
     try {
       var swapCondition = objectMapper.readValue(swapConditionJson, SwapConditionRequest.class).toEntity();
       return book.withSwapCondition(swapCondition);
@@ -220,7 +248,6 @@ public class BookController {
     if (locationJson == null || locationJson.isBlank()) {
       return book;
     }
-    var objectMapper = new ObjectMapper();
     try {
       var location = objectMapper.readValue(locationJson, BookLocationRequest.class).toEntity();
       return book.withLocation(location);

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/InboxController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/InboxController.java
@@ -61,7 +61,7 @@ public class InboxController {
     String userId = principal.getName();
     List<SwapRequest> swapRequests = inboxService.getUnifiedInbox(userId, status, sortBy);
 
-    // Batch-fetch unread counts and latest messages to avoid N+1 queries
+    // Batch-fetch unread counts to avoid N+1 queries
     List<String> swapRequestIds = swapRequests.stream().map(SwapRequest::id).toList();
     Map<String, Long> unreadCounts = inboxService.getBatchUnreadMessageCounts(userId, swapRequestIds);
 

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/InboxController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/InboxController.java
@@ -8,6 +8,7 @@ import static com.kirjaswappi.backend.common.utils.Constants.*;
 
 import java.security.Principal;
 import java.util.List;
+import java.util.Map;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -59,6 +60,11 @@ public class InboxController {
     }
     String userId = principal.getName();
     List<SwapRequest> swapRequests = inboxService.getUnifiedInbox(userId, status, sortBy);
+
+    // Batch-fetch unread counts and latest messages to avoid N+1 queries
+    List<String> swapRequestIds = swapRequests.stream().map(SwapRequest::id).toList();
+    Map<String, Long> unreadCounts = inboxService.getBatchUnreadMessageCounts(userId, swapRequestIds);
+
     List<InboxItemResponse> response = swapRequests.stream()
         .map(swapRequest -> {
           InboxItemResponse item = new InboxItemResponse(swapRequest);
@@ -74,8 +80,8 @@ public class InboxController {
             }
           }
 
-          // Add unread message count using cached version
-          long unreadCount = inboxService.getUnreadMessageCount(userId, swapRequest.id());
+          // Use batch-fetched unread count
+          long unreadCount = unreadCounts.getOrDefault(swapRequest.id(), 0L);
           item.setUnreadMessageCount(unreadCount);
           // Set notification indicators
           item.setUnread(inboxService.isInboxItemUnread(swapRequest, userId));

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/PhotoController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/PhotoController.java
@@ -146,7 +146,11 @@ public class PhotoController {
   }
 
   private void verifyPhotoOwnership(String targetUserId) {
-    String authenticatedUserId = SecurityContextHolder.getContext().getAuthentication().getName();
+    var authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication == null) {
+      throw new AccessDeniedException("notPhotoOwner", targetUserId);
+    }
+    String authenticatedUserId = authentication.getName();
     if (!authenticatedUserId.equals(targetUserId)) {
       throw new AccessDeniedException("notPhotoOwner", targetUserId);
     }

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/PhotoController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/PhotoController.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -31,6 +32,7 @@ import com.kirjaswappi.backend.http.dtos.requests.CreateSupportedCoverPhotoReque
 import com.kirjaswappi.backend.http.dtos.responses.PhotoResponse;
 import com.kirjaswappi.backend.http.dtos.responses.SupportedCoverPhotoListResponse;
 import com.kirjaswappi.backend.service.PhotoService;
+import com.kirjaswappi.backend.service.exceptions.AccessDeniedException;
 
 @RestController
 @RequestMapping(API_BASE + PHOTOS)
@@ -44,6 +46,7 @@ public class PhotoController {
   @Operation(summary = "Add profile photo.", description = "Add profile photo to a user.", responses = {
       @ApiResponse(responseCode = "200", description = "Profile photo added.") })
   public ResponseEntity<PhotoResponse> addProfilePhoto(@Valid @ModelAttribute CreatePhotoRequest request) {
+    verifyPhotoOwnership(request.getUserId());
     var imageUrl = photoService.addProfilePhoto(request.getUserId(), request.getImage());
     return ResponseEntity.ok(new PhotoResponse(imageUrl));
   }
@@ -52,6 +55,7 @@ public class PhotoController {
   @Operation(summary = "Add cover photo.", description = "Add cover photo to a user.", responses = {
       @ApiResponse(responseCode = "200", description = "Cover photo added.") })
   public ResponseEntity<PhotoResponse> addCoverPhoto(@Valid @ModelAttribute CreatePhotoRequest request) {
+    verifyPhotoOwnership(request.getUserId());
     var imageUrl = photoService.addCoverPhoto(request.getUserId(), request.getImage());
     return ResponseEntity.ok(new PhotoResponse(imageUrl));
   }
@@ -61,6 +65,7 @@ public class PhotoController {
       @ApiResponse(responseCode = "204", description = "Profile photo deleted."),
       @ApiResponse(responseCode = "404", description = "User or photo not found.") })
   public ResponseEntity<Void> deleteProfilePhoto(@Parameter(description = "User ID.") @PathVariable String id) {
+    verifyPhotoOwnership(id);
     photoService.deleteProfilePhoto(id);
     return ResponseEntity.noContent().build();
   }
@@ -70,6 +75,7 @@ public class PhotoController {
       @ApiResponse(responseCode = "204", description = "Cover photo deleted."),
       @ApiResponse(responseCode = "404", description = "User or photo not found.") })
   public ResponseEntity<Void> deleteCoverPhoto(@Parameter(description = "User ID.") @PathVariable String id) {
+    verifyPhotoOwnership(id);
     photoService.deleteCoverPhoto(id);
     return ResponseEntity.noContent().build();
   }
@@ -137,5 +143,12 @@ public class PhotoController {
       @Parameter(description = "Supported cover photo ID.") @PathVariable String id) {
     photoService.deleteSupportedCoverPhoto(id);
     return ResponseEntity.noContent().build();
+  }
+
+  private void verifyPhotoOwnership(String targetUserId) {
+    String authenticatedUserId = SecurityContextHolder.getContext().getAuthentication().getName();
+    if (!authenticatedUserId.equals(targetUserId)) {
+      throw new AccessDeniedException("notPhotoOwner", targetUserId);
+    }
   }
 }

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/SwapController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/SwapController.java
@@ -41,10 +41,11 @@ public class SwapController {
       @ApiResponse(responseCode = "201", description = "Swap request created.") })
   public ResponseEntity<SwapRequestResponse> createSwapRequest(@Valid @RequestBody CreateSwapRequest request,
       Principal principal) {
-    // Override senderId with authenticated user to prevent spoofing
-    if (principal != null) {
-      request.setSenderId(principal.getName());
+    if (principal == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     }
+    // Override senderId with authenticated user to prevent spoofing
+    request.setSenderId(principal.getName());
     SwapRequest createdSwapRequest = swapService.createSwapRequest(request.toEntity());
     return ResponseEntity.status(HttpStatus.CREATED).body(new SwapRequestResponse(createdSwapRequest));
   }

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/SwapController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/SwapController.java
@@ -39,7 +39,12 @@ public class SwapController {
   @PostMapping
   @Operation(summary = "Create swap request for a book.", description = "Create swap request for a book.", responses = {
       @ApiResponse(responseCode = "201", description = "Swap request created.") })
-  public ResponseEntity<SwapRequestResponse> createSwapRequest(@Valid @RequestBody CreateSwapRequest request) {
+  public ResponseEntity<SwapRequestResponse> createSwapRequest(@Valid @RequestBody CreateSwapRequest request,
+      Principal principal) {
+    // Override senderId with authenticated user to prevent spoofing
+    if (principal != null) {
+      request.setSenderId(principal.getName());
+    }
     SwapRequest createdSwapRequest = swapService.createSwapRequest(request.toEntity());
     return ResponseEntity.status(HttpStatus.CREATED).body(new SwapRequestResponse(createdSwapRequest));
   }

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/UserController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/UserController.java
@@ -9,6 +9,7 @@ import static com.kirjaswappi.backend.common.utils.Constants.*;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import jakarta.validation.Valid;
 
@@ -25,6 +26,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -37,6 +39,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.kirjaswappi.backend.common.http.ErrorResponse;
 import com.kirjaswappi.backend.common.service.OTPService;
 import com.kirjaswappi.backend.common.utils.JwtUtil;
 import com.kirjaswappi.backend.common.utils.LinkBuilder;
@@ -46,6 +49,7 @@ import com.kirjaswappi.backend.service.BookService;
 import com.kirjaswappi.backend.service.UserService;
 import com.kirjaswappi.backend.service.entities.Book;
 import com.kirjaswappi.backend.service.entities.User;
+import com.kirjaswappi.backend.service.exceptions.AccessDeniedException;
 import com.kirjaswappi.backend.service.exceptions.BadRequestException;
 import com.kirjaswappi.backend.service.filters.FindAllBooksFilter;
 
@@ -69,6 +73,23 @@ public class UserController {
   @Autowired
   private JwtUtil jwtUtil;
 
+  // =========== LOGIN RATE LIMITING ===========
+  private static final int MAX_LOGIN_ATTEMPTS = 10;
+  private static final long LOGIN_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+  private final ConcurrentHashMap<String, long[]> loginAttempts = new ConcurrentHashMap<>();
+
+  private boolean isLoginRateLimited(String email) {
+    long now = System.currentTimeMillis();
+    long[] entry = loginAttempts.compute(email, (key, existing) -> {
+      if (existing == null || now - existing[1] > LOGIN_RATE_LIMIT_WINDOW_MS) {
+        return new long[] { 1, now };
+      }
+      existing[0]++;
+      return existing;
+    });
+    return entry[0] > MAX_LOGIN_ATTEMPTS;
+  }
+
   @PostMapping(SIGNUP)
   @Operation(summary = "Create user.", responses = {
       @ApiResponse(responseCode = "201", description = "User created.") })
@@ -91,6 +112,7 @@ public class UserController {
   @Operation(summary = "Add a favourite book to a user.", responses = {
       @ApiResponse(responseCode = "200", description = "Book added to favourite list.") })
   public ResponseEntity<UserResponse> addFavouriteBook(@Valid @RequestBody AddFavouriteBookRequest request) {
+    verifyUserIdentity(request.toEntity().id());
     User entity = request.toEntity();
     User updatedUser = userService.addFavouriteBook(entity);
     return ResponseEntity.status(HttpStatus.OK).body(new UserResponse(updatedUser));
@@ -100,6 +122,7 @@ public class UserController {
   @Operation(summary = "Update user.", responses = {
       @ApiResponse(responseCode = "200", description = "User updated."),
       @ApiResponse(responseCode = "400", description = "Invalid request or ID mismatch."),
+      @ApiResponse(responseCode = "403", description = "Not the account owner."),
       @ApiResponse(responseCode = "404", description = "User not found.") })
   public ResponseEntity<UpdateUserResponse> updateUser(@Parameter(description = "User ID.") @PathVariable String id,
       @Valid @RequestBody UpdateUserRequest user) {
@@ -107,6 +130,7 @@ public class UserController {
     if (!id.equals(user.getId())) {
       throw new BadRequestException("idMismatch", id, user.getId());
     }
+    verifyUserIdentity(id);
     User updatedUser = userService.updateUser(user.toEntity());
     return ResponseEntity.status(HttpStatus.OK).body(new UpdateUserResponse(updatedUser));
   }
@@ -131,8 +155,10 @@ public class UserController {
   @DeleteMapping(ID)
   @Operation(summary = "Delete user.", responses = {
       @ApiResponse(responseCode = "204", description = "User deleted."),
+      @ApiResponse(responseCode = "403", description = "Not the account owner."),
       @ApiResponse(responseCode = "404", description = "User not found.") })
   public ResponseEntity<Void> deleteUser(@Parameter(description = "User ID.") @PathVariable String id) {
+    verifyUserIdentity(id);
     userService.deleteUser(id);
     return ResponseEntity.noContent().build();
   }
@@ -141,6 +167,9 @@ public class UserController {
   @Operation(summary = "Login user.", responses = {
       @ApiResponse(responseCode = "200", description = "User logged in.") })
   public ResponseEntity<UserLoginResponse> login(@Valid @RequestBody AuthenticateUserRequest authenticateUserRequest) {
+    if (isLoginRateLimited(authenticateUserRequest.getEmail().toLowerCase())) {
+      throw new BadRequestException("tooManyLoginAttempts", authenticateUserRequest.getEmail());
+    }
     User user = userService.verifyLogin(authenticateUserRequest.toEntity());
     String userToken = jwtUtil.generateUserToken(user.id(), user.email());
     String userRefreshToken = jwtUtil.generateUserRefreshToken(user.id(), user.email());
@@ -156,7 +185,8 @@ public class UserController {
     try {
       idToken = googleIdTokenVerifier.verify(request.idToken());
     } catch (Exception e) {
-      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid token");
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+          .body(new ErrorResponse(new ErrorResponse.Error("invalidGoogleToken", "Invalid Google token")));
     }
     if (idToken != null) {
       GoogleIdToken.Payload payload = idToken.getPayload();
@@ -171,7 +201,8 @@ public class UserController {
       String userRefreshToken = jwtUtil.generateUserRefreshToken(user.id(), user.email());
       return ResponseEntity.status(HttpStatus.OK).body(new UserLoginResponse(user, userToken, userRefreshToken));
     }
-    return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid ID token");
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+        .body(new ErrorResponse(new ErrorResponse.Error("invalidIdToken", "Invalid ID token")));
   }
 
   @PostMapping(CHANGE_PASSWORD + EMAIL)
@@ -187,10 +218,19 @@ public class UserController {
 
   @PostMapping(RESET_PASSWORD + EMAIL)
   @Operation(summary = "Reset password.", responses = {
-      @ApiResponse(responseCode = "200", description = "Password reset successful.") })
+      @ApiResponse(responseCode = "200", description = "Password reset successful."),
+      @ApiResponse(responseCode = "401", description = "Invalid or expired reset token.") })
   public ResponseEntity<ResetPasswordResponse> resetPassword(
       @Parameter(description = "User email.") @PathVariable String email,
       @Valid @RequestBody ResetPasswordRequest request) {
+    // Validate reset token from OTP verification
+    if (!jwtUtil.validatePasswordResetToken(request.getResetToken())) {
+      throw new BadRequestException("invalidOrExpiredResetToken", email);
+    }
+    String tokenEmail = jwtUtil.extractEmailFromResetToken(request.getResetToken());
+    if (!email.equalsIgnoreCase(tokenEmail)) {
+      throw new BadRequestException("resetTokenEmailMismatch", email);
+    }
     String userEmail = userService.changePassword(request.toUserEntity(email));
     return ResponseEntity.status(HttpStatus.OK).body(new ResetPasswordResponse(userEmail));
   }
@@ -225,5 +265,12 @@ public class UserController {
     Page<Book> books = bookService.getUserBooksByFilter(id, filter, pageable);
     Page<BookListResponse> response = books.map(BookListResponse::new);
     return ResponseEntity.status(HttpStatus.OK).body(LinkBuilder.forPage(response, API_BASE + USERS + ID + BOOKS));
+  }
+
+  private void verifyUserIdentity(String targetUserId) {
+    String authenticatedUserId = SecurityContextHolder.getContext().getAuthentication().getName();
+    if (!authenticatedUserId.equals(targetUserId)) {
+      throw new AccessDeniedException("notAccountOwner", targetUserId);
+    }
   }
 }

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/UserController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/UserController.java
@@ -80,14 +80,30 @@ public class UserController {
 
   private boolean isLoginRateLimited(String email) {
     long now = System.currentTimeMillis();
-    long[] entry = loginAttempts.compute(email, (key, existing) -> {
+    long[] entry = loginAttempts.get(email);
+    if (entry == null) {
+      return false;
+    }
+    if (now - entry[1] > LOGIN_RATE_LIMIT_WINDOW_MS) {
+      loginAttempts.remove(email);
+      return false;
+    }
+    return entry[0] > MAX_LOGIN_ATTEMPTS;
+  }
+
+  private void recordFailedLogin(String email) {
+    long now = System.currentTimeMillis();
+    loginAttempts.compute(email, (key, existing) -> {
       if (existing == null || now - existing[1] > LOGIN_RATE_LIMIT_WINDOW_MS) {
         return new long[] { 1, now };
       }
       existing[0]++;
       return existing;
     });
-    return entry[0] > MAX_LOGIN_ATTEMPTS;
+  }
+
+  private void clearLoginAttempts(String email) {
+    loginAttempts.remove(email);
   }
 
   @PostMapping(SIGNUP)
@@ -171,10 +187,20 @@ public class UserController {
     if (email != null && isLoginRateLimited(email.toLowerCase())) {
       throw new BadRequestException("tooManyLoginAttempts", email);
     }
-    User user = userService.verifyLogin(authenticateUserRequest.toEntity());
-    String userToken = jwtUtil.generateUserToken(user.id(), user.email());
-    String userRefreshToken = jwtUtil.generateUserRefreshToken(user.id(), user.email());
-    return ResponseEntity.status(HttpStatus.OK).body(new UserLoginResponse(user, userToken, userRefreshToken));
+    try {
+      User user = userService.verifyLogin(authenticateUserRequest.toEntity());
+      if (email != null) {
+        clearLoginAttempts(email.toLowerCase());
+      }
+      String userToken = jwtUtil.generateUserToken(user.id(), user.email());
+      String userRefreshToken = jwtUtil.generateUserRefreshToken(user.id(), user.email());
+      return ResponseEntity.status(HttpStatus.OK).body(new UserLoginResponse(user, userToken, userRefreshToken));
+    } catch (Exception e) {
+      if (email != null) {
+        recordFailedLogin(email.toLowerCase());
+      }
+      throw e;
+    }
   }
 
   @PostMapping(LOGIN_WITH_GOOGLE)
@@ -220,7 +246,7 @@ public class UserController {
   @PostMapping(RESET_PASSWORD + EMAIL)
   @Operation(summary = "Reset password.", responses = {
       @ApiResponse(responseCode = "200", description = "Password reset successful."),
-      @ApiResponse(responseCode = "401", description = "Invalid or expired reset token.") })
+      @ApiResponse(responseCode = "400", description = "Invalid or expired reset token.") })
   public ResponseEntity<ResetPasswordResponse> resetPassword(
       @Parameter(description = "User email.") @PathVariable String email,
       @Valid @RequestBody ResetPasswordRequest request) {
@@ -269,7 +295,11 @@ public class UserController {
   }
 
   private void verifyUserIdentity(String targetUserId) {
-    String authenticatedUserId = SecurityContextHolder.getContext().getAuthentication().getName();
+    var authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication == null) {
+      throw new AccessDeniedException("notAccountOwner", targetUserId);
+    }
+    String authenticatedUserId = authentication.getName();
     if (!authenticatedUserId.equals(targetUserId)) {
       throw new AccessDeniedException("notAccountOwner", targetUserId);
     }

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/UserController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/UserController.java
@@ -167,8 +167,9 @@ public class UserController {
   @Operation(summary = "Login user.", responses = {
       @ApiResponse(responseCode = "200", description = "User logged in.") })
   public ResponseEntity<UserLoginResponse> login(@Valid @RequestBody AuthenticateUserRequest authenticateUserRequest) {
-    if (isLoginRateLimited(authenticateUserRequest.getEmail().toLowerCase())) {
-      throw new BadRequestException("tooManyLoginAttempts", authenticateUserRequest.getEmail());
+    String email = authenticateUserRequest.getEmail();
+    if (email != null && isLoginRateLimited(email.toLowerCase())) {
+      throw new BadRequestException("tooManyLoginAttempts", email);
     }
     User user = userService.verifyLogin(authenticateUserRequest.toEntity());
     String userToken = jwtUtil.generateUserToken(user.id(), user.email());

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/UserController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/UserController.java
@@ -7,9 +7,9 @@ package com.kirjaswappi.backend.http.controllers;
 import static com.kirjaswappi.backend.common.utils.Constants.*;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import jakarta.validation.Valid;
 
@@ -41,6 +41,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.kirjaswappi.backend.common.http.ErrorResponse;
 import com.kirjaswappi.backend.common.service.OTPService;
+import com.kirjaswappi.backend.common.service.RateLimiterService;
 import com.kirjaswappi.backend.common.utils.JwtUtil;
 import com.kirjaswappi.backend.common.utils.LinkBuilder;
 import com.kirjaswappi.backend.http.dtos.requests.*;
@@ -73,38 +74,12 @@ public class UserController {
   @Autowired
   private JwtUtil jwtUtil;
 
-  // =========== LOGIN RATE LIMITING ===========
+  @Autowired
+  private RateLimiterService rateLimiterService;
+
   private static final int MAX_LOGIN_ATTEMPTS = 10;
-  private static final long LOGIN_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
-  private final ConcurrentHashMap<String, long[]> loginAttempts = new ConcurrentHashMap<>();
-
-  private boolean isLoginRateLimited(String email) {
-    long now = System.currentTimeMillis();
-    long[] entry = loginAttempts.get(email);
-    if (entry == null) {
-      return false;
-    }
-    if (now - entry[1] > LOGIN_RATE_LIMIT_WINDOW_MS) {
-      loginAttempts.remove(email);
-      return false;
-    }
-    return entry[0] >= MAX_LOGIN_ATTEMPTS;
-  }
-
-  private void recordFailedLogin(String email) {
-    long now = System.currentTimeMillis();
-    loginAttempts.compute(email, (key, existing) -> {
-      if (existing == null || now - existing[1] > LOGIN_RATE_LIMIT_WINDOW_MS) {
-        return new long[] { 1, now };
-      }
-      existing[0]++;
-      return existing;
-    });
-  }
-
-  private void clearLoginAttempts(String email) {
-    loginAttempts.remove(email);
-  }
+  private static final Duration LOGIN_RATE_LIMIT_WINDOW = Duration.ofMinutes(15);
+  private static final String LOGIN_RATE_LIMIT_PREFIX = "ratelimit:login:";
 
   @PostMapping(SIGNUP)
   @Operation(summary = "Create user.", responses = {
@@ -184,20 +159,21 @@ public class UserController {
       @ApiResponse(responseCode = "200", description = "User logged in.") })
   public ResponseEntity<UserLoginResponse> login(@Valid @RequestBody AuthenticateUserRequest authenticateUserRequest) {
     String email = authenticateUserRequest.getEmail();
-    if (email != null && isLoginRateLimited(email.toLowerCase())) {
+    String rateLimitKey = email != null ? LOGIN_RATE_LIMIT_PREFIX + email.toLowerCase() : null;
+    if (rateLimitKey != null && rateLimiterService.isRateLimited(rateLimitKey, MAX_LOGIN_ATTEMPTS)) {
       throw new BadRequestException("tooManyLoginAttempts", email);
     }
     try {
       User user = userService.verifyLogin(authenticateUserRequest.toEntity());
-      if (email != null) {
-        clearLoginAttempts(email.toLowerCase());
+      if (rateLimitKey != null) {
+        rateLimiterService.clearAttempts(rateLimitKey);
       }
       String userToken = jwtUtil.generateUserToken(user.id(), user.email());
       String userRefreshToken = jwtUtil.generateUserRefreshToken(user.id(), user.email());
       return ResponseEntity.status(HttpStatus.OK).body(new UserLoginResponse(user, userToken, userRefreshToken));
     } catch (Exception e) {
-      if (email != null) {
-        recordFailedLogin(email.toLowerCase());
+      if (rateLimitKey != null) {
+        rateLimiterService.recordAttempt(rateLimitKey, LOGIN_RATE_LIMIT_WINDOW);
       }
       throw e;
     }

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/UserController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/UserController.java
@@ -88,7 +88,7 @@ public class UserController {
       loginAttempts.remove(email);
       return false;
     }
-    return entry[0] > MAX_LOGIN_ATTEMPTS;
+    return entry[0] >= MAX_LOGIN_ATTEMPTS;
   }
 
   private void recordFailedLogin(String email) {

--- a/src/main/java/com/kirjaswappi/backend/http/dtos/requests/ChangePasswordRequest.java
+++ b/src/main/java/com/kirjaswappi/backend/http/dtos/requests/ChangePasswordRequest.java
@@ -52,9 +52,7 @@ public class ChangePasswordRequest {
       throw new BadRequestException("currentPasswordCannotBeBlank", this.currentPassword);
     }
     // validate new password:
-    if (!ValidationUtil.validateNotBlank(this.newPassword)) {
-      throw new BadRequestException("newPasswordCannotBeBlank", this.newPassword);
-    }
+    ValidationUtil.validatePassword(this.newPassword, "newPassword");
     // validate confirm password:
     if (!ValidationUtil.validateNotBlank(this.confirmPassword)) {
       throw new BadRequestException("confirmPasswordCannotBeBlank", this.confirmPassword);

--- a/src/main/java/com/kirjaswappi/backend/http/dtos/requests/CreateUserRequest.java
+++ b/src/main/java/com/kirjaswappi/backend/http/dtos/requests/CreateUserRequest.java
@@ -56,9 +56,7 @@ public class CreateUserRequest {
       throw new BadRequestException("invalidEmailAddress", this.email);
     }
     // validate password:
-    if (!ValidationUtil.validateNotBlank(this.password)) {
-      throw new BadRequestException("passwordCannotBeBlank", this.password);
-    }
+    ValidationUtil.validatePassword(this.password, "password");
     // validate confirm password:
     if (!ValidationUtil.validateNotBlank(this.confirmPassword)) {
       throw new BadRequestException("confirmPasswordCannotBeBlank", this.confirmPassword);

--- a/src/main/java/com/kirjaswappi/backend/http/dtos/requests/ResetPasswordRequest.java
+++ b/src/main/java/com/kirjaswappi/backend/http/dtos/requests/ResetPasswordRequest.java
@@ -23,6 +23,9 @@ public class ResetPasswordRequest {
   @Schema(description = "The confirm password of the user.", example = "newPassword", requiredMode = REQUIRED)
   private String confirmPassword;
 
+  @Schema(description = "The reset token obtained from OTP verification.", example = "eyJhbGciOiJIUzI1NiJ9...", requiredMode = REQUIRED)
+  private String resetToken;
+
   public User toUserEntity(String email) {
 
     this.validateProperties(email);
@@ -38,10 +41,12 @@ public class ResetPasswordRequest {
     if (!ValidationUtil.validateEmail(email)) {
       throw new BadRequestException("invalidEmailAddress", email);
     }
-    // validate new password:
-    if (!ValidationUtil.validateNotBlank(this.newPassword)) {
-      throw new BadRequestException("newPasswordCannotBeBlank", this.newPassword);
+    // validate reset token:
+    if (!ValidationUtil.validateNotBlank(this.resetToken)) {
+      throw new BadRequestException("resetTokenRequired", email);
     }
+    // validate new password:
+    ValidationUtil.validatePassword(this.newPassword, "newPassword");
     // validate confirm password:
     if (!ValidationUtil.validateNotBlank(this.confirmPassword)) {
       throw new BadRequestException("confirmPasswordCannotBeBlank", this.confirmPassword);

--- a/src/main/java/com/kirjaswappi/backend/http/validations/ValidationUtil.java
+++ b/src/main/java/com/kirjaswappi/backend/http/validations/ValidationUtil.java
@@ -29,19 +29,19 @@ public class ValidationUtil {
 
   public static void validatePassword(String password, String fieldName) {
     if (password == null || password.trim().isEmpty()) {
-      throw new BadRequestException(fieldName + "CannotBeBlank", password);
+      throw new BadRequestException(fieldName + "CannotBeBlank", fieldName);
     }
     if (password.length() < 8) {
-      throw new BadRequestException("passwordTooShort", password);
+      throw new BadRequestException("passwordTooShort", fieldName);
     }
     if (!Pattern.compile("[A-Z]").matcher(password).find()) {
-      throw new BadRequestException("passwordMissingUppercase", password);
+      throw new BadRequestException("passwordMissingUppercase", fieldName);
     }
     if (!Pattern.compile("[a-z]").matcher(password).find()) {
-      throw new BadRequestException("passwordMissingLowercase", password);
+      throw new BadRequestException("passwordMissingLowercase", fieldName);
     }
     if (!Pattern.compile("[0-9]").matcher(password).find()) {
-      throw new BadRequestException("passwordMissingDigit", password);
+      throw new BadRequestException("passwordMissingDigit", fieldName);
     }
   }
 

--- a/src/main/java/com/kirjaswappi/backend/http/validations/ValidationUtil.java
+++ b/src/main/java/com/kirjaswappi/backend/http/validations/ValidationUtil.java
@@ -27,6 +27,24 @@ public class ValidationUtil {
     return Pattern.compile(regexPattern).matcher(emailAddress).matches();
   }
 
+  public static void validatePassword(String password, String fieldName) {
+    if (password == null || password.trim().isEmpty()) {
+      throw new BadRequestException(fieldName + "CannotBeBlank", password);
+    }
+    if (password.length() < 8) {
+      throw new BadRequestException("passwordTooShort", password);
+    }
+    if (!Pattern.compile("[A-Z]").matcher(password).find()) {
+      throw new BadRequestException("passwordMissingUppercase", password);
+    }
+    if (!Pattern.compile("[a-z]").matcher(password).find()) {
+      throw new BadRequestException("passwordMissingLowercase", password);
+    }
+    if (!Pattern.compile("[0-9]").matcher(password).find()) {
+      throw new BadRequestException("passwordMissingDigit", password);
+    }
+  }
+
   public static boolean validateOtp(String otp) {
     return otp == null
         || otp.trim().isEmpty()

--- a/src/main/java/com/kirjaswappi/backend/jpa/daos/UserDao.java
+++ b/src/main/java/com/kirjaswappi/backend/jpa/daos/UserDao.java
@@ -12,6 +12,7 @@ import lombok.*;
 import lombok.experimental.Accessors;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.DBRef;
 import org.springframework.data.mongodb.core.mapping.Document;
 
@@ -35,6 +36,7 @@ public class UserDao {
   private String lastName;
 
   @NotNull
+  @Indexed(unique = true)
   private String email;
 
   @NotNull

--- a/src/main/java/com/kirjaswappi/backend/jpa/repositories/BookRepository.java
+++ b/src/main/java/com/kirjaswappi/backend/jpa/repositories/BookRepository.java
@@ -17,4 +17,6 @@ public interface BookRepository extends MongoRepository<BookDao, String>, Custom
   List<BookDao> findAllByIsDeletedFalse();
 
   Optional<BookDao> findByIsDeletedFalseAndSwapConditionSwappableBooksId(String swappableBookId);
+
+  boolean existsByGenresId(String genreId);
 }

--- a/src/main/java/com/kirjaswappi/backend/jpa/repositories/ChatMessageRepository.java
+++ b/src/main/java/com/kirjaswappi/backend/jpa/repositories/ChatMessageRepository.java
@@ -13,7 +13,8 @@ import org.springframework.data.mongodb.repository.Query;
 
 import com.kirjaswappi.backend.jpa.daos.ChatMessageDao;
 
-public interface ChatMessageRepository extends MongoRepository<ChatMessageDao, String> {
+public interface ChatMessageRepository
+    extends MongoRepository<ChatMessageDao, String>, CustomChatMessageRepository {
   List<ChatMessageDao> findBySwapRequestIdOrderBySentAtAsc(String swapRequestId);
 
   @Query(value = "{ 'swapRequestId': ?0, 'readByReceiver': false, 'sender.$id': { $ne: ?1 } }", count = true)

--- a/src/main/java/com/kirjaswappi/backend/jpa/repositories/ChatMessageRepository.java
+++ b/src/main/java/com/kirjaswappi/backend/jpa/repositories/ChatMessageRepository.java
@@ -26,4 +26,6 @@ public interface ChatMessageRepository
 
   @Query(value = "{ 'swapRequestId': { $in: ?0 }, 'readByReceiver': false, 'sender.$id': { $ne: ?1 } }")
   List<ChatMessageDao> findUnreadBySwapRequestIdInAndSenderIdNot(List<String> swapRequestIds, ObjectId userId);
+
+  void deleteAllBySwapRequestIdIn(List<String> swapRequestIds);
 }

--- a/src/main/java/com/kirjaswappi/backend/jpa/repositories/ChatMessageRepository.java
+++ b/src/main/java/com/kirjaswappi/backend/jpa/repositories/ChatMessageRepository.java
@@ -22,4 +22,7 @@ public interface ChatMessageRepository extends MongoRepository<ChatMessageDao, S
   Optional<ChatMessageDao> findFirstBySwapRequestIdOrderBySentAtDesc(String swapRequestId);
 
   List<ChatMessageDao> findBySwapRequestIdInOrderBySentAtDesc(List<String> swapRequestIds);
+
+  @Query(value = "{ 'swapRequestId': { $in: ?0 }, 'readByReceiver': false, 'sender.$id': { $ne: ?1 } }")
+  List<ChatMessageDao> findUnreadBySwapRequestIdInAndSenderIdNot(List<String> swapRequestIds, ObjectId userId);
 }

--- a/src/main/java/com/kirjaswappi/backend/jpa/repositories/CustomChatMessageRepository.java
+++ b/src/main/java/com/kirjaswappi/backend/jpa/repositories/CustomChatMessageRepository.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 KirjaSwappi or KirjaSwappi affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+package com.kirjaswappi.backend.jpa.repositories;
+
+public interface CustomChatMessageRepository {
+  long markAsRead(String swapRequestId, String userId);
+}

--- a/src/main/java/com/kirjaswappi/backend/jpa/repositories/CustomChatMessageRepositoryImpl.java
+++ b/src/main/java/com/kirjaswappi/backend/jpa/repositories/CustomChatMessageRepositoryImpl.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 KirjaSwappi or KirjaSwappi affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+package com.kirjaswappi.backend.jpa.repositories;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class CustomChatMessageRepositoryImpl implements CustomChatMessageRepository {
+
+  private final MongoTemplate mongoTemplate;
+
+  public CustomChatMessageRepositoryImpl(MongoTemplate mongoTemplate) {
+    this.mongoTemplate = mongoTemplate;
+  }
+
+  @Override
+  public long markAsRead(String swapRequestId, String userId) {
+    Query query = new Query(Criteria.where("swapRequestId").is(swapRequestId)
+        .and("readByReceiver").is(false)
+        .and("sender.$id").ne(new ObjectId(userId)));
+    Update update = new Update().set("readByReceiver", true);
+    return mongoTemplate.updateMulti(query, update, "chatMessages").getModifiedCount();
+  }
+}

--- a/src/main/java/com/kirjaswappi/backend/jpa/repositories/SwapRequestRepository.java
+++ b/src/main/java/com/kirjaswappi/backend/jpa/repositories/SwapRequestRepository.java
@@ -32,4 +32,8 @@ public interface SwapRequestRepository extends MongoRepository<SwapRequestDao, S
 
   // Find active swap requests for a specific book
   List<SwapRequestDao> findByBookToSwapWithIdAndSwapStatus(String bookToSwapWithId, String swapStatus);
+
+  void deleteAllBySenderId(String senderId);
+
+  void deleteAllByReceiverId(String receiverId);
 }

--- a/src/main/java/com/kirjaswappi/backend/jpa/repositories/UserRepository.java
+++ b/src/main/java/com/kirjaswappi/backend/jpa/repositories/UserRepository.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.data.mongodb.repository.Query;
 
 import com.kirjaswappi.backend.jpa.daos.UserDao;
 
@@ -23,6 +22,5 @@ public interface UserRepository extends MongoRepository<UserDao, String> {
 
   List<UserDao> findAllByIsEmailVerifiedTrue();
 
-  @Query(value = "{ '$or': [ { 'favGenres.$id': ObjectId(?0) }, { 'books.genres.$id': ObjectId(?0) } ] }", exists = true)
-  boolean existsByGenreId(String genreId);
+  boolean existsByFavGenresId(String genreId);
 }

--- a/src/main/java/com/kirjaswappi/backend/jpa/repositories/UserRepository.java
+++ b/src/main/java/com/kirjaswappi/backend/jpa/repositories/UserRepository.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 
 import com.kirjaswappi.backend.jpa.daos.UserDao;
 
@@ -21,4 +22,7 @@ public interface UserRepository extends MongoRepository<UserDao, String> {
   Optional<UserDao> findByIdAndIsEmailVerifiedTrue(String id);
 
   List<UserDao> findAllByIsEmailVerifiedTrue();
+
+  @Query(value = "{ '$or': [ { 'favGenres.$id': ObjectId(?0) }, { 'books.genres.$id': ObjectId(?0) } ] }", exists = true)
+  boolean existsByGenreId(String genreId);
 }

--- a/src/main/java/com/kirjaswappi/backend/service/BookService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/BookService.java
@@ -39,6 +39,7 @@ import com.kirjaswappi.backend.mapper.*;
 import com.kirjaswappi.backend.service.entities.Book;
 import com.kirjaswappi.backend.service.entities.Genre;
 import com.kirjaswappi.backend.service.entities.SwappableBook;
+import com.kirjaswappi.backend.service.enums.SwapStatus;
 import com.kirjaswappi.backend.service.exceptions.BookNotFoundException;
 import com.kirjaswappi.backend.service.exceptions.UserNotFoundException;
 import com.kirjaswappi.backend.service.filters.FindAllBooksFilter;
@@ -375,7 +376,9 @@ public class BookService {
     var bookDao = bookRepository.findByIdAndIsDeletedFalse(bookId)
         .orElseThrow(() -> new BookNotFoundException(bookId));
     var owner = bookDao.owner();
-    assert owner.books() != null;
+    if (owner.books() == null) {
+      return List.of();
+    }
     return owner.books().stream()
         .filter(book -> !book.id().equals(bookId)) // Exclude the current book
         .map(this::bookWithImageUrlAndOwner).toList();
@@ -447,10 +450,29 @@ public class BookService {
 
       var swapRequests = swapRequestRepository.findByBookToSwapWithIdAndSwapStatus(bookId, "PENDING");
       for (var request : swapRequests) {
+        // Cancel pending swap requests when book is deleted
+        if ("deleted".equals(action)) {
+          request.swapStatus(SwapStatus.CANCELLED.getCode());
+          swapRequestRepository.save(request);
+        }
         String title = "Book " + action.substring(0, 1).toUpperCase() + action.substring(1);
         String message = String.format("The book '%s' you requested has been %s by its owner.",
             bookDao.title(), action);
         notificationClient.sendNotification(request.sender().id(), title, message);
+      }
+
+      // Also cancel accepted/reserved swap requests when book is deleted
+      if ("deleted".equals(action)) {
+        for (String status : List.of("ACCEPTED", "RESERVED")) {
+          var activeRequests = swapRequestRepository.findByBookToSwapWithIdAndSwapStatus(bookId, status);
+          for (var request : activeRequests) {
+            request.swapStatus(SwapStatus.CANCELLED.getCode());
+            swapRequestRepository.save(request);
+            String message = String.format("The book '%s' you requested has been deleted by its owner.",
+                bookDao.title());
+            notificationClient.sendNotification(request.sender().id(), "Book Deleted", message);
+          }
+        }
       }
     } catch (Exception e) {
       log.error("Failed to notify swap request senders about book change. BookId: {}", bookId, e);

--- a/src/main/java/com/kirjaswappi/backend/service/BookService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/BookService.java
@@ -448,7 +448,8 @@ public class BookService {
       if (bookDao == null)
         return;
 
-      var swapRequests = swapRequestRepository.findByBookToSwapWithIdAndSwapStatus(bookId, "PENDING");
+      var swapRequests = swapRequestRepository.findByBookToSwapWithIdAndSwapStatus(bookId,
+          SwapStatus.PENDING.getCode());
       for (var request : swapRequests) {
         // Cancel pending swap requests when book is deleted
         if ("deleted".equals(action)) {
@@ -463,7 +464,7 @@ public class BookService {
 
       // Also cancel accepted/reserved swap requests when book is deleted
       if ("deleted".equals(action)) {
-        for (String status : List.of("ACCEPTED", "RESERVED")) {
+        for (String status : List.of(SwapStatus.ACCEPTED.getCode(), SwapStatus.RESERVED.getCode())) {
           var activeRequests = swapRequestRepository.findByBookToSwapWithIdAndSwapStatus(bookId, status);
           for (var request : activeRequests) {
             request.swapStatus(SwapStatus.CANCELLED.getCode());

--- a/src/main/java/com/kirjaswappi/backend/service/ChatService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/ChatService.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import org.bson.types.ObjectId;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -33,9 +34,11 @@ import com.kirjaswappi.backend.mapper.SwapRequestMapper;
 import com.kirjaswappi.backend.service.entities.ChatMessage;
 import com.kirjaswappi.backend.service.entities.SwapRequest;
 import com.kirjaswappi.backend.service.entities.User;
+import com.kirjaswappi.backend.service.exceptions.BadRequestException;
 import com.kirjaswappi.backend.service.exceptions.ChatAccessDeniedException;
 import com.kirjaswappi.backend.service.exceptions.SwapRequestNotFoundException;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -101,7 +104,7 @@ public class ChatService {
 
     // Validate message content
     if (message == null || message.trim().isEmpty()) {
-      throw new IllegalArgumentException("Message cannot be empty");
+      throw new BadRequestException("messageCannotBeBlank");
     }
 
     // Get sender user
@@ -141,7 +144,7 @@ public class ChatService {
     boolean hasImages = images != null && !images.isEmpty();
 
     if (!hasMessage && !hasImages) {
-      throw new IllegalArgumentException("Either message text or images must be provided");
+      throw new BadRequestException("messageOrImageRequired");
     }
 
     // Validate swap request exists
@@ -166,7 +169,7 @@ public class ChatService {
       long maxImageSize = 5 * 1024 * 1024; // 5MB per image
       for (MultipartFile image : images) {
         if (image.getSize() > maxImageSize) {
-          throw new IllegalArgumentException("Image size exceeds 5MB limit");
+          throw new BadRequestException("imageSizeExceedsLimit");
         }
         String uniqueId = UUID.randomUUID().toString();
         imageService.uploadImage(image, uniqueId);
@@ -345,6 +348,7 @@ public class ChatService {
             try {
               messagingTemplate.convertAndSendToUser(userId, "/queue/inbox.refresh", "refresh");
             } catch (Exception e) {
+              log.debug("Failed to broadcast inbox update to user {}: {}", userId, e.getMessage());
             }
           }
         });
@@ -352,8 +356,7 @@ public class ChatService {
         messagingTemplate.convertAndSendToUser(userId, "/queue/inbox.refresh", "refresh");
       }
     } catch (Exception e) {
-      // Log error but don't fail the message sending
-      // Real-time updates are nice-to-have, not critical
+      log.debug("Failed to register inbox broadcast for user {}: {}", userId, e.getMessage());
     }
   }
 }

--- a/src/main/java/com/kirjaswappi/backend/service/ChatService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/ChatService.java
@@ -220,21 +220,8 @@ public class ChatService {
       throw new ChatAccessDeniedException();
     }
 
-    // Get all messages in this chat that are not from the current user and are
-    // unread
-    List<ChatMessageDao> allMessages = chatMessageRepository.findBySwapRequestIdOrderBySentAtAsc(swapRequestId);
-    List<ChatMessageDao> unreadMessages = allMessages
-        .stream()
-        .filter(msg -> !msg.sender().id().equals(userId) && !msg.readByReceiver())
-        .toList();
-
-    // Mark messages as read
-    for (ChatMessageDao message : unreadMessages) {
-      message.readByReceiver(true);
-    }
-    if (!unreadMessages.isEmpty()) {
-      chatMessageRepository.saveAll(unreadMessages);
-    }
+    // Bulk-update unread messages in a single DB operation
+    chatMessageRepository.markAsRead(swapRequestId, userId);
 
     // Also mark the swap request inbox item as read so the inbox endpoint returns
     // unread=false

--- a/src/main/java/com/kirjaswappi/backend/service/ChatService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/ChatService.java
@@ -163,7 +163,11 @@ public class ChatService {
     // Upload images and get unique IDs
     List<String> imageIds = new ArrayList<>();
     if (images != null && !images.isEmpty()) {
+      long maxImageSize = 5 * 1024 * 1024; // 5MB per image
       for (MultipartFile image : images) {
+        if (image.getSize() > maxImageSize) {
+          throw new IllegalArgumentException("Image size exceeds 5MB limit");
+        }
         String uniqueId = UUID.randomUUID().toString();
         imageService.uploadImage(image, uniqueId);
         imageIds.add(uniqueId);
@@ -288,6 +292,19 @@ public class ChatService {
     Map<String, Instant> result = new HashMap<>();
     for (ChatMessageDao msg : messages) {
       result.putIfAbsent(msg.swapRequestId(), msg.sentAt());
+    }
+    return result;
+  }
+
+  public Map<String, Long> getBatchUnreadMessageCounts(List<String> swapRequestIds, String userId) {
+    if (swapRequestIds == null || swapRequestIds.isEmpty()) {
+      return Map.of();
+    }
+    List<ChatMessageDao> unreadMessages = chatMessageRepository
+        .findUnreadBySwapRequestIdInAndSenderIdNot(swapRequestIds, new ObjectId(userId));
+    Map<String, Long> result = new HashMap<>();
+    for (ChatMessageDao msg : unreadMessages) {
+      result.merge(msg.swapRequestId(), 1L, Long::sum);
     }
     return result;
   }

--- a/src/main/java/com/kirjaswappi/backend/service/GenreService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/GenreService.java
@@ -21,7 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.kirjaswappi.backend.http.dtos.responses.NestedGenresResponse;
 import com.kirjaswappi.backend.http.dtos.responses.ParentGenreResponse;
-import com.kirjaswappi.backend.jpa.daos.UserDao;
 import com.kirjaswappi.backend.jpa.repositories.GenreRepository;
 import com.kirjaswappi.backend.jpa.repositories.UserRepository;
 import com.kirjaswappi.backend.mapper.GenreMapper;
@@ -148,19 +147,7 @@ public class GenreService {
   }
 
   private boolean isIsBeingGenreUsed(String id) {
-    return userRepository.findAll().stream().anyMatch(user -> isGenreInFavGenres(user, id) || isGenreInBooks(user, id));
-  }
-
-  private boolean isGenreInFavGenres(UserDao user, String id) {
-    return user.favGenres() != null
-        && user.favGenres().stream().anyMatch(favGenre -> favGenre.id().equals(id));
-  }
-
-  private boolean isGenreInBooks(UserDao user, String id) {
-    return user.books() != null && user.books().stream()
-        .anyMatch(book -> book.genres().stream().anyMatch(genre -> genre.id().equals(id)) ||
-            (book.swapCondition() != null &&
-                book.swapCondition().swappableGenres().stream().anyMatch(g -> g.id().equals(id))));
+    return userRepository.existsByGenreId(id);
   }
 
   @CacheEvict(value = { "genres", "nested_genres" }, allEntries = true)

--- a/src/main/java/com/kirjaswappi/backend/service/GenreService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/GenreService.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.kirjaswappi.backend.http.dtos.responses.NestedGenresResponse;
 import com.kirjaswappi.backend.http.dtos.responses.ParentGenreResponse;
+import com.kirjaswappi.backend.jpa.repositories.BookRepository;
 import com.kirjaswappi.backend.jpa.repositories.GenreRepository;
 import com.kirjaswappi.backend.jpa.repositories.UserRepository;
 import com.kirjaswappi.backend.mapper.GenreMapper;
@@ -38,6 +39,8 @@ public class GenreService {
   private final GenreRepository genreRepository;
 
   private final UserRepository userRepository;
+
+  private final BookRepository bookRepository;
 
   @Cacheable(value = "genres")
   public List<Genre> getGenres() {
@@ -147,7 +150,7 @@ public class GenreService {
   }
 
   private boolean isIsBeingGenreUsed(String id) {
-    return userRepository.existsByGenreId(id);
+    return userRepository.existsByFavGenresId(id) || bookRepository.existsByGenresId(id);
   }
 
   @CacheEvict(value = { "genres", "nested_genres" }, allEntries = true)

--- a/src/main/java/com/kirjaswappi/backend/service/InboxService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/InboxService.java
@@ -141,6 +141,10 @@ public class InboxService {
     return chatService.getUnreadMessageCount(swapRequestId, userId);
   }
 
+  public Map<String, Long> getBatchUnreadMessageCounts(String userId, List<String> swapRequestIds) {
+    return chatService.getBatchUnreadMessageCounts(swapRequestIds, userId);
+  }
+
   public void markInboxItemAsRead(String swapRequestId, String userId) {
     // Get swap request
     Optional<SwapRequestDao> swapRequestOpt = swapRequestRepository.findById(swapRequestId);
@@ -230,16 +234,27 @@ public class InboxService {
   }
 
   private boolean canUpdateStatus(SwapRequestDao swapRequest, String userId, SwapStatus newStatus) {
-    // Receiver can accept, reject, or mark as reserved
-    if (swapRequest.receiver().id().equals(userId)) {
-      return newStatus == SwapStatus.ACCEPTED ||
-          newStatus == SwapStatus.REJECTED ||
-          newStatus == SwapStatus.RESERVED;
+    boolean isReceiver = swapRequest.receiver().id().equals(userId);
+    boolean isSender = swapRequest.sender().id().equals(userId);
+
+    if (!isReceiver && !isSender) {
+      return false;
     }
 
-    // Sender can only mark as expired (cancel their own request)
-    if (swapRequest.sender().id().equals(userId)) {
-      return newStatus == SwapStatus.EXPIRED;
+    // Accept/Reject/Reserve are receiver-only actions
+    if (newStatus == SwapStatus.ACCEPTED || newStatus == SwapStatus.REJECTED
+        || newStatus == SwapStatus.RESERVED) {
+      return isReceiver;
+    }
+
+    // Complete and Cancel can be done by either participant
+    if (newStatus == SwapStatus.COMPLETED || newStatus == SwapStatus.CANCELLED) {
+      return true;
+    }
+
+    // Expired can be triggered by sender (withdraw) or system
+    if (newStatus == SwapStatus.EXPIRED) {
+      return isSender;
     }
 
     return false;

--- a/src/main/java/com/kirjaswappi/backend/service/SwapService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/SwapService.java
@@ -150,8 +150,9 @@ public class SwapService {
       throw new IllegalSwapRequestException("onlyParticipantsCanChangeStatus");
     }
 
-    // Only receivers can accept/reject; both can cancel/complete
-    if ((newStatus == SwapStatus.ACCEPTED || newStatus == SwapStatus.REJECTED) && !isReceiver) {
+    // Only receivers can accept/reject/reserve; both can cancel/complete
+    if ((newStatus == SwapStatus.ACCEPTED || newStatus == SwapStatus.REJECTED || newStatus == SwapStatus.RESERVED)
+        && !isReceiver) {
       throw new IllegalSwapRequestException("onlyReceiverCanChangeStatus");
     }
 

--- a/src/main/java/com/kirjaswappi/backend/service/SwapService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/SwapService.java
@@ -142,8 +142,16 @@ public class SwapService {
     SwapRequestDao swapRequestDao = swapRequestDaoOpt.get();
     SwapRequest swapRequest = SwapRequestMapper.toEntity(swapRequestDao);
 
-    // Validate that the user is the receiver (only receivers can change status)
-    if (!swapRequest.receiver().id().equals(userId)) {
+    // Validate that the user is a participant
+    boolean isSender = swapRequest.sender().id().equals(userId);
+    boolean isReceiver = swapRequest.receiver().id().equals(userId);
+
+    if (!isSender && !isReceiver) {
+      throw new IllegalSwapRequestException("onlyParticipantsCanChangeStatus");
+    }
+
+    // Only receivers can accept/reject; both can cancel/complete
+    if ((newStatus == SwapStatus.ACCEPTED || newStatus == SwapStatus.REJECTED) && !isReceiver) {
       throw new IllegalSwapRequestException("onlyReceiverCanChangeStatus");
     }
 

--- a/src/main/java/com/kirjaswappi/backend/service/SwapService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/SwapService.java
@@ -150,10 +150,13 @@ public class SwapService {
       throw new IllegalSwapRequestException("onlyParticipantsCanChangeStatus");
     }
 
-    // Only receivers can accept/reject/reserve; both can cancel/complete
+    // Only receivers can accept/reject/reserve; only senders can expire
     if ((newStatus == SwapStatus.ACCEPTED || newStatus == SwapStatus.REJECTED || newStatus == SwapStatus.RESERVED)
         && !isReceiver) {
       throw new IllegalSwapRequestException("onlyReceiverCanChangeStatus");
+    }
+    if (newStatus == SwapStatus.EXPIRED && !isSender) {
+      throw new IllegalSwapRequestException("onlySenderCanExpire");
     }
 
     SwapStatus currentStatus = swapRequest.swapStatus();

--- a/src/main/java/com/kirjaswappi/backend/service/UserService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/UserService.java
@@ -20,6 +20,7 @@ import com.kirjaswappi.backend.common.utils.Util;
 import com.kirjaswappi.backend.jpa.daos.BookDao;
 import com.kirjaswappi.backend.jpa.daos.UserDao;
 import com.kirjaswappi.backend.jpa.repositories.BookRepository;
+import com.kirjaswappi.backend.jpa.repositories.ChatMessageRepository;
 import com.kirjaswappi.backend.jpa.repositories.GenreRepository;
 import com.kirjaswappi.backend.jpa.repositories.SwapRequestRepository;
 import com.kirjaswappi.backend.jpa.repositories.UserRepository;
@@ -42,6 +43,8 @@ public class UserService {
   private final PhotoService photoService;
 
   private final BookRepository bookRepository;
+
+  private final ChatMessageRepository chatMessageRepository;
 
   private final SwapRequestRepository swapRequestRepository;
 
@@ -121,6 +124,18 @@ public class UserService {
     // validate user exists:
     var dao = userRepository.findById(id)
         .orElseThrow(() -> new UserNotFoundException(id));
+
+    // Collect swap request IDs for chat message cleanup
+    List<String> swapRequestIds = new ArrayList<>();
+    swapRequestRepository.findBySenderIdOrderByRequestedAtDesc(id)
+        .forEach(sr -> swapRequestIds.add(sr.id()));
+    swapRequestRepository.findByReceiverIdOrderByRequestedAtDesc(id)
+        .forEach(sr -> swapRequestIds.add(sr.id()));
+
+    // Delete chat messages for these swap requests
+    if (!swapRequestIds.isEmpty()) {
+      chatMessageRepository.deleteAllBySwapRequestIdIn(swapRequestIds);
+    }
 
     // Delete all swap requests involving this user
     swapRequestRepository.deleteAllBySenderId(id);

--- a/src/main/java/com/kirjaswappi/backend/service/UserService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/UserService.java
@@ -21,6 +21,7 @@ import com.kirjaswappi.backend.jpa.daos.BookDao;
 import com.kirjaswappi.backend.jpa.daos.UserDao;
 import com.kirjaswappi.backend.jpa.repositories.BookRepository;
 import com.kirjaswappi.backend.jpa.repositories.GenreRepository;
+import com.kirjaswappi.backend.jpa.repositories.SwapRequestRepository;
 import com.kirjaswappi.backend.jpa.repositories.UserRepository;
 import com.kirjaswappi.backend.mapper.UserMapper;
 import com.kirjaswappi.backend.service.entities.User;
@@ -41,6 +42,8 @@ public class UserService {
   private final PhotoService photoService;
 
   private final BookRepository bookRepository;
+
+  private final SwapRequestRepository swapRequestRepository;
 
   private final EmailService emailService;
 
@@ -118,6 +121,36 @@ public class UserService {
     // validate user exists:
     var dao = userRepository.findById(id)
         .orElseThrow(() -> new UserNotFoundException(id));
+
+    // Cancel all active swap requests involving this user (as sender or receiver)
+    var sentRequests = swapRequestRepository.findBySenderIdOrderByRequestedAtDesc(id);
+    var receivedRequests = swapRequestRepository.findByReceiverIdOrderByRequestedAtDesc(id);
+    for (var request : sentRequests) {
+      swapRequestRepository.deleteById(request.id());
+    }
+    for (var request : receivedRequests) {
+      swapRequestRepository.deleteById(request.id());
+    }
+
+    // Soft-delete all books owned by this user
+    if (dao.books() != null) {
+      for (var book : dao.books()) {
+        bookRepository.deleteLogically(book.id());
+      }
+    }
+
+    // Delete photos
+    try {
+      if (dao.profilePhoto() != null) {
+        photoService.deleteProfilePhoto(dao.profilePhoto());
+      }
+      if (dao.coverPhoto() != null) {
+        photoService.deleteCoverPhoto(dao.coverPhoto());
+      }
+    } catch (Exception ignored) {
+      // Best-effort photo cleanup
+    }
+
     userRepository.delete(dao);
   }
 
@@ -282,6 +315,7 @@ public class UserService {
     }
   }
 
+  @CacheEvict(value = "users", key = "#userId")
   public void unblockUser(String userId, String targetUserId) {
     var dao = userRepository.findByIdAndIsEmailVerifiedTrue(userId)
         .orElseThrow(() -> new UserNotFoundException(userId));
@@ -310,6 +344,7 @@ public class UserService {
     }
   }
 
+  @CacheEvict(value = "users", key = "#userId")
   public void unmuteUser(String userId, String targetUserId) {
     var dao = userRepository.findByIdAndIsEmailVerifiedTrue(userId)
         .orElseThrow(() -> new UserNotFoundException(userId));

--- a/src/main/java/com/kirjaswappi/backend/service/UserService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/UserService.java
@@ -142,10 +142,10 @@ public class UserService {
     // Delete photos
     try {
       if (dao.profilePhoto() != null) {
-        photoService.deleteProfilePhoto(dao.profilePhoto());
+        photoService.deleteProfilePhoto(dao.id());
       }
       if (dao.coverPhoto() != null) {
-        photoService.deleteCoverPhoto(dao.coverPhoto());
+        photoService.deleteCoverPhoto(dao.id());
       }
     } catch (Exception ignored) {
       // Best-effort photo cleanup
@@ -220,7 +220,7 @@ public class UserService {
 
     // validate email and password:
     if (userRepository.findByEmailAndPassword(dao.email(), password).isEmpty()) {
-      throw new BadRequestException("currentPasswordMismatch", user.password());
+      throw new BadRequestException("currentPasswordMismatch", user.email());
     }
   }
 
@@ -238,7 +238,7 @@ public class UserService {
     String currentPassword = dao.password();
     String newPassword = Util.hashPassword(user.password(), dao.salt());
     if (currentPassword.equals(newPassword)) {
-      throw new BadRequestException("newPasswordCannotBeSameAsCurrentPassword", user.password());
+      throw new BadRequestException("newPasswordCannotBeSameAsCurrentPassword", user.email());
     }
 
     // add new salt to new password:

--- a/src/main/java/com/kirjaswappi/backend/service/UserService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/UserService.java
@@ -122,15 +122,9 @@ public class UserService {
     var dao = userRepository.findById(id)
         .orElseThrow(() -> new UserNotFoundException(id));
 
-    // Cancel all active swap requests involving this user (as sender or receiver)
-    var sentRequests = swapRequestRepository.findBySenderIdOrderByRequestedAtDesc(id);
-    var receivedRequests = swapRequestRepository.findByReceiverIdOrderByRequestedAtDesc(id);
-    for (var request : sentRequests) {
-      swapRequestRepository.deleteById(request.id());
-    }
-    for (var request : receivedRequests) {
-      swapRequestRepository.deleteById(request.id());
-    }
+    // Delete all swap requests involving this user
+    swapRequestRepository.deleteAllBySenderId(id);
+    swapRequestRepository.deleteAllByReceiverId(id);
 
     // Soft-delete all books owned by this user
     if (dao.books() != null) {

--- a/src/main/java/com/kirjaswappi/backend/service/enums/SwapStatus.java
+++ b/src/main/java/com/kirjaswappi/backend/service/enums/SwapStatus.java
@@ -20,7 +20,9 @@ public enum SwapStatus {
   ACCEPTED("Accepted"),
   RESERVED("Reserved"),
   REJECTED("Rejected"),
-  EXPIRED("Expired");
+  EXPIRED("Expired"),
+  COMPLETED("Completed"),
+  CANCELLED("Cancelled");
 
   private final String code;
 
@@ -34,10 +36,10 @@ public enum SwapStatus {
 
   private Set<SwapStatus> getAllowedTransitions() {
     return switch (this) {
-    case PENDING -> Set.of(ACCEPTED, REJECTED, EXPIRED);
-    case ACCEPTED -> Set.of(RESERVED, EXPIRED);
-    case RESERVED -> Set.of(EXPIRED);
-    case REJECTED, EXPIRED -> Set.of();
+    case PENDING -> Set.of(ACCEPTED, REJECTED, EXPIRED, CANCELLED);
+    case ACCEPTED -> Set.of(RESERVED, EXPIRED, COMPLETED, CANCELLED);
+    case RESERVED -> Set.of(EXPIRED, COMPLETED, CANCELLED);
+    case REJECTED, EXPIRED, COMPLETED, CANCELLED -> Set.of();
     };
   }
 

--- a/src/main/java/com/kirjaswappi/backend/service/exceptions/AccessDeniedException.java
+++ b/src/main/java/com/kirjaswappi/backend/service/exceptions/AccessDeniedException.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 KirjaSwappi or KirjaSwappi affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+package com.kirjaswappi.backend.service.exceptions;
+
+import com.kirjaswappi.backend.common.exceptions.BusinessException;
+
+public class AccessDeniedException extends BusinessException {
+  public AccessDeniedException(String messageKey, Object... params) {
+    super(messageKey, params);
+  }
+}

--- a/src/main/java/com/kirjaswappi/backend/service/filters/FindAllBooksFilter.java
+++ b/src/main/java/com/kirjaswappi/backend/service/filters/FindAllBooksFilter.java
@@ -53,6 +53,18 @@ public class FindAllBooksFilter {
   @Schema(description = "Filter books by country", example = "Finland")
   String country;
 
+  @Schema(description = "Bounding box north latitude for map view", example = "61.0")
+  Double north;
+
+  @Schema(description = "Bounding box south latitude for map view", example = "59.0")
+  Double south;
+
+  @Schema(description = "Bounding box east longitude for map view", example = "26.0")
+  Double east;
+
+  @Schema(description = "Bounding box west longitude for map view", example = "23.0")
+  Double west;
+
   @Schema(description = "Sort field for ordering results. Use with Pageable's 'sort' parameter.", example = "createdAt", allowableValues = {
       "title", "author", "createdAt", "condition", "language" })
   String sortBy;
@@ -161,6 +173,12 @@ public class FindAllBooksFilter {
     // Filter by country if provided:
     if (country != null && !country.isEmpty()) {
       combinedCriteria.add(Criteria.where("location.country").regex(country, "i"));
+    }
+
+    // Filter by map bounding box if provided:
+    if (north != null && south != null && east != null && west != null) {
+      combinedCriteria.add(Criteria.where("location.latitude").gte(south).lte(north));
+      combinedCriteria.add(Criteria.where("location.longitude").gte(west).lte(east));
     }
 
     var finalCriteria = new Criteria();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -95,4 +95,4 @@ management:
         include: health,prometheus
     endpoint:
       health:
-        show-details: always
+        show-details: when_authorized

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -93,6 +93,6 @@ management:
     web:
       exposure:
         include: health,prometheus
-    endpoint:
-      health:
-        show-details: when_authorized
+  endpoint:
+    health:
+      show-details: when_authorized

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -233,3 +233,93 @@ reasonCannotBeBlank=Please provide a reason for the report.
 
 #NOTR: Error message in case of an invalid form type
 invalidFormType=Invalid form type: {0}.
+
+#NOTR: Error message in case of null email
+emailCannotBeNull=Please provide an email address.
+
+#NOTR: Error message in case of too many OTP verification attempts
+tooManyVerifyAttempts=Too many verification attempts. Please try again later.
+
+#NOTR: Error message in case of too many OTP send attempts
+tooManySendOtpAttempts=Too many OTP requests. Please try again later.
+
+#NOTR: Error message in case of too many login attempts
+tooManyLoginAttempts=Too many login attempts. Please try again later.
+
+#NOTR: Error message in case of invalid or expired password reset token
+invalidOrExpiredResetToken=The password reset link is invalid or has expired.
+
+#NOTR: Error message in case of reset token email mismatch
+resetTokenEmailMismatch=The reset token does not match the provided email.
+
+#NOTR: Error message in case of missing reset token
+resetTokenRequired=Please provide a password reset token.
+
+#NOTR: Error message in case of missing map bounds
+allMapBoundsRequired=All map bounds (north, south, east, west) are required.
+
+#NOTR: Error message in case of invalid map bounds
+invalidMapBounds=Invalid map bounds: north must be greater than south, east must be greater than west.
+
+#NOTR: Error message in case of password too short
+passwordTooShort=Password must be at least 8 characters long.
+
+#NOTR: Error message in case of password missing uppercase
+passwordMissingUppercase=Password must contain at least one uppercase letter.
+
+#NOTR: Error message in case of password missing lowercase
+passwordMissingLowercase=Password must contain at least one lowercase letter.
+
+#NOTR: Error message in case of password missing digit
+passwordMissingDigit=Password must contain at least one digit.
+
+#NOTR: Error message in case of user not being the account owner
+notAccountOwner=You are not the owner of this account.
+
+#NOTR: Error message in case of user not being the book owner
+notBookOwner=You are not the owner of this book.
+
+#NOTR: Error message in case of user not being the photo owner
+notPhotoOwner=You are not the owner of this photo.
+
+#NOTR: Error message in case of non-participants trying to change swap status
+onlyParticipantsCanChangeStatus=Only participants of the swap request can change its status.
+
+#NOTR: Error message in case of non-receiver trying to change swap status
+onlyReceiverCanChangeStatus=Only the receiver can accept, reject, or reserve a swap request.
+
+#NOTR: Error message in case of invalid UUID
+invalidUUID=Please provide a valid ID.
+
+#NOTR: Error message in case of blank ID
+idCannotBeBlank=Please provide an ID.
+
+#NOTR: Error message in case of blank role
+roleCannotBeBlank=Please provide a role.
+
+#NOTR: Error message in case of blank username
+usernameCannotBeBlank=Please provide a username.
+
+#NOTR: Error message in case of blank author for swappable book
+authorCannotBeBlankForSwappableBook=Please provide an author for the swappable book.
+
+#NOTR: Error message in case of blank title for swappable book
+bookTitleCannotBeBlankForSwappableBook=Please provide a title for the swappable book.
+
+#NOTR: Error message in case of missing cover photo for swappable book
+coverPhotoIsRequiredForSwappableBook=Please provide a cover photo for the swappable book.
+
+#NOTR: Error message in case of blank genre for swappable condition
+genreCannotBeBlankForSwappableCondition=Please provide a genre for the swappable condition.
+
+#NOTR: Error message in case of invalid swappable book cover photo
+invalidSwappableBookCoverPhoto=Please provide a valid cover photo for the swappable book.
+
+#NOTR: Error message in case of invalid location request
+invalidLocationRequest=Please provide valid location parameters.
+
+#NOTR: Error message in case of message or image required in chat
+messageOrImageRequired=Please provide either a message or images.
+
+#NOTR: Error message in case of image size exceeds limit
+imageSizeExceedsLimit=Image size exceeds the 5MB limit.

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -213,6 +213,9 @@ statusCannotBeBlank=Please provide a status.
 #NOTR: An error message in case of user trying to request swap for their own.
 senderAndReceiverCannotBeSame=You cannot request swap for your own book.
 
+#NOTR: An error message in case of only sender can expire a swap request.
+onlySenderCanExpire=Only the sender can expire a swap request.
+
 #NOTR: An error message in case of a photo not found.
 photoNotFound=Photo does not exist.
 

--- a/src/test/java/com/kirjaswappi/backend/common/http/controllers/mockMvc/OTPControllerTest.java
+++ b/src/test/java/com/kirjaswappi/backend/common/http/controllers/mockMvc/OTPControllerTest.java
@@ -34,6 +34,9 @@ class OTPControllerTest {
   @MockitoBean
   private OTPService otpService;
 
+  @MockitoBean
+  private com.kirjaswappi.backend.common.utils.JwtUtil jwtUtil;
+
   @Autowired
   private ObjectMapper objectMapper;
 

--- a/src/test/java/com/kirjaswappi/backend/common/service/OTPServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/common/service/OTPServiceTest.java
@@ -33,6 +33,8 @@ class OTPServiceTest {
   private UserService userService;
   @Mock
   private EmailService emailService;
+  @Mock
+  private RateLimiterService rateLimiterService;
   @InjectMocks
   private OTPService otpService;
 

--- a/src/test/java/com/kirjaswappi/backend/common/service/OTPServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/common/service/OTPServiceTest.java
@@ -94,7 +94,7 @@ class OTPServiceTest {
   @Test
   @DisplayName("Should throw exception when saveAndSendOTP called with null email")
   void saveAndSendOTPThrowsOnNullEmail() {
-    assertThrows(UserNotFoundException.class, () -> otpService.saveAndSendOTP(null));
+    assertThrows(BadRequestException.class, () -> otpService.saveAndSendOTP(null));
   }
 
   @Test

--- a/src/test/java/com/kirjaswappi/backend/common/service/OTPServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/common/service/OTPServiceTest.java
@@ -88,7 +88,7 @@ class OTPServiceTest {
   @DisplayName("Should throw exception when email is null in OTP")
   void verifyOTPThrowsOnNullEmail() {
     OTP nullEmailOtp = OTP.builder().email(null).otp(otpValue).createdAt(Instant.now()).build();
-    assertThrows(ResourceNotFoundException.class, () -> otpService.verifyOTPByEmail(nullEmailOtp));
+    assertThrows(BadRequestException.class, () -> otpService.verifyOTPByEmail(nullEmailOtp));
   }
 
   @Test

--- a/src/test/java/com/kirjaswappi/backend/http/controllers/RealtimeChatControllerTest.java
+++ b/src/test/java/com/kirjaswappi/backend/http/controllers/RealtimeChatControllerTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2025 KirjaSwappi or KirjaSwappi affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+package com.kirjaswappi.backend.http.controllers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import com.kirjaswappi.backend.http.dtos.requests.SendMessageRequest;
+import com.kirjaswappi.backend.service.ChatService;
+import com.kirjaswappi.backend.service.entities.*;
+import com.kirjaswappi.backend.service.enums.*;
+
+class RealtimeChatControllerTest {
+
+  @Mock
+  private ChatService chatService;
+
+  @Mock
+  private SimpMessagingTemplate messagingTemplate;
+
+  @InjectMocks
+  private RealtimeChatController realtimeChatController;
+
+  private User sender;
+  private User receiver;
+  private SwapRequest swapRequest;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+
+    sender = new User().id("user-1").firstName("Alice").lastName("Smith");
+    receiver = new User().id("user-2").firstName("Bob").lastName("Jones");
+
+    Book book = Book.builder()
+        .id("book-1")
+        .title("Test Book")
+        .author("Author")
+        .condition(Condition.GOOD)
+        .coverPhotos(List.of())
+        .build();
+
+    swapRequest = SwapRequest.builder()
+        .id("swap-1")
+        .sender(sender)
+        .receiver(receiver)
+        .bookToSwapWith(book)
+        .swapType(SwapType.GIVE_AWAY)
+        .swapStatus(SwapStatus.PENDING)
+        .askForGiveaway(false)
+        .build();
+  }
+
+  @Test
+  @DisplayName("Should send message to both sender and receiver")
+  void shouldSendMessageToBothUsers() {
+    String swapRequestId = "swap-1";
+    String userId = "user-1";
+
+    SendMessageRequest request = new SendMessageRequest();
+    request.setMessage("Hello!");
+
+    ChatMessage message = ChatMessage.builder()
+        .id("msg-1")
+        .swapRequestId(swapRequestId)
+        .sender(sender)
+        .message("Hello!")
+        .sentAt(Instant.now())
+        .readByReceiver(false)
+        .build();
+
+    when(chatService.sendMessage(swapRequestId, userId, "Hello!")).thenReturn(message);
+    when(chatService.getSwapRequestForChat(swapRequestId, userId)).thenReturn(swapRequest);
+
+    realtimeChatController.sendMessage(swapRequestId, request, () -> userId);
+
+    // Verify message sent to sender
+    verify(messagingTemplate).convertAndSendToUser(
+        eq("user-1"), eq("/queue/chat.swap-1"), any());
+    // Verify message sent to receiver
+    verify(messagingTemplate).convertAndSendToUser(
+        eq("user-2"), eq("/queue/chat.swap-1"), any());
+  }
+
+  @Test
+  @DisplayName("Should send message when receiver is the sender of the STOMP message")
+  void shouldSendMessageWhenReceiverSendsMessage() {
+    String swapRequestId = "swap-1";
+    String userId = "user-2"; // Receiver of the swap is sending a chat message
+
+    SendMessageRequest request = new SendMessageRequest();
+    request.setMessage("Sure!");
+
+    ChatMessage message = ChatMessage.builder()
+        .id("msg-2")
+        .swapRequestId(swapRequestId)
+        .sender(receiver)
+        .message("Sure!")
+        .sentAt(Instant.now())
+        .readByReceiver(false)
+        .build();
+
+    when(chatService.sendMessage(swapRequestId, userId, "Sure!")).thenReturn(message);
+    when(chatService.getSwapRequestForChat(swapRequestId, userId)).thenReturn(swapRequest);
+
+    realtimeChatController.sendMessage(swapRequestId, request, () -> userId);
+
+    // Verify message sent to user-2 (the current sender)
+    verify(messagingTemplate).convertAndSendToUser(
+        eq("user-2"), eq("/queue/chat.swap-1"), any());
+    // Verify message sent to user-1 (the other party)
+    verify(messagingTemplate).convertAndSendToUser(
+        eq("user-1"), eq("/queue/chat.swap-1"), any());
+  }
+
+  @Test
+  @DisplayName("Should not send message when request is invalid")
+  void shouldNotSendMessageWhenRequestInvalid() {
+    SendMessageRequest request = new SendMessageRequest();
+    // Both message and images are null → isValid() returns false
+
+    realtimeChatController.sendMessage("swap-1", request, () -> "user-1");
+
+    verify(chatService, never()).sendMessage(any(), any(), any());
+    verify(messagingTemplate, never()).convertAndSendToUser(any(), any(), any(Object.class));
+  }
+
+  @Test
+  @DisplayName("Should handle exception from chat service gracefully")
+  void shouldHandleExceptionGracefully() {
+    SendMessageRequest request = new SendMessageRequest();
+    request.setMessage("Hello!");
+
+    when(chatService.sendMessage(any(), any(), any())).thenThrow(new RuntimeException("DB error"));
+
+    // Should not throw — exception is caught internally
+    realtimeChatController.sendMessage("swap-1", request, () -> "user-1");
+
+    verify(messagingTemplate, never()).convertAndSendToUser(any(), any(), any(Object.class));
+  }
+
+  @Test
+  @DisplayName("Should handle null principal gracefully")
+  void shouldHandleNullPrincipalGracefully() {
+    SendMessageRequest request = new SendMessageRequest();
+    request.setMessage("Hello!");
+
+    // Principal.getName() will throw NPE, caught by the try-catch
+    realtimeChatController.sendMessage("swap-1", request, null);
+
+    verify(chatService, never()).sendMessage(any(), any(), any());
+    verify(messagingTemplate, never()).convertAndSendToUser(any(), any(), any(Object.class));
+  }
+}

--- a/src/test/java/com/kirjaswappi/backend/http/controllers/RealtimeInboxControllerTest.java
+++ b/src/test/java/com/kirjaswappi/backend/http/controllers/RealtimeInboxControllerTest.java
@@ -6,9 +6,9 @@ package com.kirjaswappi.backend.http.controllers;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -76,5 +76,63 @@ class RealtimeInboxControllerTest {
         eq(userId),
         eq("/queue/inbox.item-update"), // Critical check: ensuring delta path
         any(Object.class));
+  }
+
+  @Test
+  @DisplayName("Should send full inbox on subscribe")
+  void shouldSendFullInboxOnSubscribe() {
+    String userId = "user1";
+
+    SwapRequest mockRequest = SwapRequest.builder()
+        .id("swap1")
+        .sender(new User().id(userId).firstName("Test").lastName("User"))
+        .receiver(new User().id("other").firstName("Other").lastName("User"))
+        .bookToSwapWith(Book.builder().id("book1").title("Book").build())
+        .swapType(SwapType.GIVE_AWAY)
+        .swapStatus(SwapStatus.PENDING)
+        .build();
+
+    when(inboxService.getUnifiedInbox(userId, null, null)).thenReturn(List.of(mockRequest));
+    when(inboxService.getUnreadMessageCount(userId, "swap1")).thenReturn(0L);
+    when(inboxService.isInboxItemUnread(any(), eq(userId))).thenReturn(false);
+
+    realtimeInboxController.subscribeToInbox(() -> userId);
+
+    verify(inboxService).getUnifiedInbox(userId, null, null);
+    verify(messagingTemplate).convertAndSendToUser(
+        eq(userId), eq("/queue/inbox.update"), any(List.class));
+  }
+
+  @Test
+  @DisplayName("Should send full inbox on refresh")
+  void shouldSendFullInboxOnRefresh() {
+    String userId = "user1";
+
+    when(inboxService.getUnifiedInbox(userId, null, null)).thenReturn(List.of());
+
+    realtimeInboxController.refreshInbox(() -> userId);
+
+    verify(inboxService).getUnifiedInbox(userId, null, null);
+    verify(messagingTemplate).convertAndSendToUser(
+        eq(userId), eq("/queue/inbox.update"), any(List.class));
+  }
+
+  @Test
+  @DisplayName("Should handle exception in subscribe gracefully")
+  void shouldHandleExceptionInSubscribeGracefully() {
+    // null principal → NPE caught by try-catch
+    realtimeInboxController.subscribeToInbox(null);
+
+    verify(inboxService, never()).getUnifiedInbox(any(), any(), any());
+    verify(messagingTemplate, never()).convertAndSendToUser(any(), any(), any(Object.class));
+  }
+
+  @Test
+  @DisplayName("Should handle exception in refresh gracefully")
+  void shouldHandleExceptionInRefreshGracefully() {
+    realtimeInboxController.refreshInbox(null);
+
+    verify(inboxService, never()).getUnifiedInbox(any(), any(), any());
+    verify(messagingTemplate, never()).convertAndSendToUser(any(), any(), any(Object.class));
   }
 }

--- a/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/BookControllerEdgeCaseTest.java
+++ b/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/BookControllerEdgeCaseTest.java
@@ -223,25 +223,23 @@ class BookControllerEdgeCaseTest {
   class BookNotFoundTests {
 
     @Test
-    @DisplayName("Should return 400 when book not found by ID")
-    void shouldReturn400WhenBookNotFoundById() throws Exception {
-      // BookNotFoundException extends BusinessException which returns 400 BAD_REQUEST
+    @DisplayName("Should return 404 when book not found by ID")
+    void shouldReturn404WhenBookNotFoundById() throws Exception {
       when(bookService.getBookById("nonexistent-id"))
           .thenThrow(new BookNotFoundException());
 
       mockMvc.perform(get(API_BASE + "/nonexistent-id"))
-          .andExpect(status().isBadRequest());
+          .andExpect(status().isNotFound());
     }
 
     @Test
-    @DisplayName("Should return 400 when getting more books for nonexistent book")
-    void shouldReturn400WhenGettingMoreBooksForNonexistent() throws Exception {
-      // BookNotFoundException extends BusinessException which returns 400 BAD_REQUEST
+    @DisplayName("Should return 404 when getting more books for nonexistent book")
+    void shouldReturn404WhenGettingMoreBooksForNonexistent() throws Exception {
       when(bookService.getMoreBooksOfTheUser("nonexistent-id"))
           .thenThrow(new BookNotFoundException());
 
       mockMvc.perform(get(API_BASE + "/nonexistent-id/more-books"))
-          .andExpect(status().isBadRequest());
+          .andExpect(status().isNotFound());
     }
   }
 

--- a/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/BookControllerTest.java
+++ b/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/BookControllerTest.java
@@ -25,6 +25,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -178,6 +179,7 @@ class BookControllerTest {
   }
 
   @Test
+  @WithMockUser(username = "user-123")
   @DisplayName("Should update a Book with swap type ByBooks successfully")
   void shouldUpdateBookWithConditionTypeByBooksSuccessfully() throws Exception {
     String swapCondition = """
@@ -194,7 +196,9 @@ class BookControllerTest {
         }
         """;
 
-    Book book = Book.builder().id("123").title("The Alchemist").build();
+    Book book = Book.builder().id("123").title("The Alchemist")
+        .owner(User.builder().id("user-123").build()).build();
+    when(bookService.getBookById("123")).thenReturn(book);
     Mockito.when(bookService.updateBook(any(Book.class))).thenReturn(book);
 
     mockMvc.perform(multipart(BASE_PATH + "/123")
@@ -217,6 +221,7 @@ class BookControllerTest {
   }
 
   @Test
+  @WithMockUser(username = "user-123")
   @DisplayName("Should update a Book with swap type ByGenres successfully")
   void shouldUpdateBookWithConditionTypeByGenresSuccessfully() throws Exception {
     String swapCondition = """
@@ -229,7 +234,9 @@ class BookControllerTest {
         }
         """;
 
-    Book book = Book.builder().id("123").title("The Alchemist").build();
+    Book book = Book.builder().id("123").title("The Alchemist")
+        .owner(User.builder().id("user-123").build()).build();
+    when(bookService.getBookById("123")).thenReturn(book);
     Mockito.when(bookService.updateBook(any(Book.class))).thenReturn(book);
 
     mockMvc.perform(multipart(BASE_PATH + "/123")
@@ -252,6 +259,7 @@ class BookControllerTest {
   }
 
   @Test
+  @WithMockUser(username = "user-123")
   @DisplayName("Should update a Book with swap type GiveAway successfully")
   void shouldUpdateBookWithConditionTypeByGiveAwaySuccessfully() throws Exception {
     String swapCondition = """
@@ -264,7 +272,9 @@ class BookControllerTest {
         }
         """;
 
-    Book book = Book.builder().id("123").title("The Alchemist").build();
+    Book book = Book.builder().id("123").title("The Alchemist")
+        .owner(User.builder().id("user-123").build()).build();
+    when(bookService.getBookById("123")).thenReturn(book);
     Mockito.when(bookService.updateBook(any(Book.class))).thenReturn(book);
 
     mockMvc.perform(multipart(BASE_PATH + "/123")
@@ -287,6 +297,7 @@ class BookControllerTest {
   }
 
   @Test
+  @WithMockUser(username = "user-123")
   @DisplayName("Should update a Book with swap type OpenForOffers successfully")
   void shouldUpdateBookWithConditionTypeByOpenForOffersSuccessfully() throws Exception {
     String swapCondition = """
@@ -299,7 +310,9 @@ class BookControllerTest {
         }
         """;
 
-    Book book = Book.builder().id("123").title("The Alchemist").build();
+    Book book = Book.builder().id("123").title("The Alchemist")
+        .owner(User.builder().id("user-123").build()).build();
+    when(bookService.getBookById("123")).thenReturn(book);
     Mockito.when(bookService.updateBook(any(Book.class))).thenReturn(book);
 
     mockMvc.perform(multipart(BASE_PATH + "/123")
@@ -461,8 +474,12 @@ class BookControllerTest {
   }
 
   @Test
+  @WithMockUser(username = "user-123")
   @DisplayName("Should delete a book successfully")
   void shouldReturnNoContentWhenDeletingSingleBook() throws Exception {
+    Book book = Book.builder().id("book123")
+        .owner(User.builder().id("user-123").build()).build();
+    when(bookService.getBookById("book123")).thenReturn(book);
     doNothing().when(bookService).deleteBook("book123");
     mockMvc.perform(delete(BASE_PATH + "/book123"))
         .andExpect(status().isNoContent());

--- a/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/InboxControllerTest.java
+++ b/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/InboxControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -103,8 +104,8 @@ class InboxControllerTest {
 
     List<SwapRequest> unifiedInbox = Arrays.asList(sentSwap, receivedSwap); // Sorted by latest messages
     when(inboxService.getUnifiedInbox("receiver123", null, null)).thenReturn(unifiedInbox);
-    when(inboxService.getUnreadMessageCount("receiver123", "received1")).thenReturn(2L);
-    when(inboxService.getUnreadMessageCount("receiver123", "sent1")).thenReturn(0L);
+    when(inboxService.getBatchUnreadMessageCounts("receiver123", List.of("sent1", "received1")))
+        .thenReturn(Map.of("received1", 2L, "sent1", 0L));
     when(inboxService.isInboxItemUnread(receivedSwap, "receiver123")).thenReturn(true);
     when(inboxService.isInboxItemUnread(sentSwap, "receiver123")).thenReturn(false);
 
@@ -141,8 +142,7 @@ class InboxControllerTest {
         .andExpect(jsonPath("$[1].hasNewMessages").value(true));
 
     verify(inboxService).getUnifiedInbox("receiver123", null, null);
-    verify(inboxService).getUnreadMessageCount("receiver123", "received1");
-    verify(inboxService).getUnreadMessageCount("receiver123", "sent1");
+    verify(inboxService).getBatchUnreadMessageCounts("receiver123", List.of("sent1", "received1"));
     verify(inboxService).isInboxItemUnread(receivedSwap, "receiver123");
     verify(inboxService).isInboxItemUnread(sentSwap, "receiver123");
   }
@@ -183,7 +183,8 @@ class InboxControllerTest {
 
     List<SwapRequest> swapRequests = List.of(swapRequest);
     when(inboxService.getUnifiedInbox("receiver123", "Pending", "latest_message")).thenReturn(swapRequests);
-    when(inboxService.getUnreadMessageCount("receiver123", "swap1")).thenReturn(1L);
+    when(inboxService.getBatchUnreadMessageCounts("receiver123", List.of("swap1")))
+        .thenReturn(Map.of("swap1", 1L));
     when(inboxService.isInboxItemUnread(swapRequest, "receiver123")).thenReturn(true);
 
     // When & Then
@@ -201,7 +202,7 @@ class InboxControllerTest {
         .andExpect(jsonPath("$[0].conversationType").value("received"));
 
     verify(inboxService).getUnifiedInbox("receiver123", "Pending", "latest_message");
-    verify(inboxService).getUnreadMessageCount("receiver123", "swap1");
+    verify(inboxService).getBatchUnreadMessageCounts("receiver123", List.of("swap1"));
     verify(inboxService).isInboxItemUnread(swapRequest, "receiver123");
   }
 
@@ -292,8 +293,8 @@ class InboxControllerTest {
     List<SwapRequest> swapRequests = Arrays.asList(swapRequest1, swapRequest2); // Sorted alphabetically by book
                                                                                 // title
     when(inboxService.getUnifiedInbox("receiver123", null, "book_title")).thenReturn(swapRequests);
-    when(inboxService.getUnreadMessageCount("receiver123", "swap1")).thenReturn(0L);
-    when(inboxService.getUnreadMessageCount("receiver123", "swap2")).thenReturn(0L);
+    when(inboxService.getBatchUnreadMessageCounts("receiver123", List.of("swap1", "swap2")))
+        .thenReturn(Map.of("swap1", 0L, "swap2", 0L));
     when(inboxService.isInboxItemUnread(swapRequest1, "receiver123")).thenReturn(false);
     when(inboxService.isInboxItemUnread(swapRequest2, "receiver123")).thenReturn(false);
 
@@ -311,8 +312,7 @@ class InboxControllerTest {
         .andExpect(jsonPath("$[1].bookToSwapWith.title").value("Z Test Book"));
 
     verify(inboxService).getUnifiedInbox("receiver123", null, "book_title");
-    verify(inboxService).getUnreadMessageCount("receiver123", "swap1");
-    verify(inboxService).getUnreadMessageCount("receiver123", "swap2");
+    verify(inboxService).getBatchUnreadMessageCounts("receiver123", List.of("swap1", "swap2"));
     verify(inboxService).isInboxItemUnread(swapRequest1, "receiver123");
     verify(inboxService).isInboxItemUnread(swapRequest2, "receiver123");
   }
@@ -353,7 +353,8 @@ class InboxControllerTest {
 
     List<SwapRequest> swapRequests = List.of(swapRequest);
     when(inboxService.getUnifiedInbox("receiver123", null, null)).thenReturn(swapRequests);
-    when(inboxService.getUnreadMessageCount("receiver123", "swap1")).thenReturn(1L);
+    when(inboxService.getBatchUnreadMessageCounts("receiver123", List.of("swap1")))
+        .thenReturn(Map.of("swap1", 1L));
     when(inboxService.isInboxItemUnread(swapRequest, "receiver123")).thenReturn(true);
 
     // Mock latest message with image but no text
@@ -423,7 +424,8 @@ class InboxControllerTest {
         .build();
 
     when(inboxService.getUnifiedInbox("receiver123", null, null)).thenReturn(List.of(swapRequest));
-    when(inboxService.getUnreadMessageCount("receiver123", "swap1")).thenReturn(0L);
+    when(inboxService.getBatchUnreadMessageCounts("receiver123", List.of("swap1")))
+        .thenReturn(Map.of("swap1", 0L));
     when(inboxService.isInboxItemUnread(swapRequest, "receiver123")).thenReturn(false);
     when(photoService.getBookCoverPhoto("cover-photo-id-123"))
         .thenReturn("https://minio.example.com/presigned-url");
@@ -473,7 +475,8 @@ class InboxControllerTest {
         .build();
 
     when(inboxService.getUnifiedInbox("receiver123", null, null)).thenReturn(List.of(swapRequest));
-    when(inboxService.getUnreadMessageCount("receiver123", "swap1")).thenReturn(0L);
+    when(inboxService.getBatchUnreadMessageCounts("receiver123", List.of("swap1")))
+        .thenReturn(Map.of("swap1", 0L));
     when(inboxService.isInboxItemUnread(swapRequest, "receiver123")).thenReturn(false);
     when(photoService.getBookCoverPhoto("missing-photo-id"))
         .thenThrow(new PhotoNotFoundException());

--- a/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/PhotoControllerTest.java
+++ b/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/PhotoControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -46,6 +47,7 @@ class PhotoControllerTest {
       MediaType.IMAGE_JPEG_VALUE, "dummy".getBytes());
 
   @Test
+  @WithMockUser(username = "user123")
   @DisplayName("Should upload profile photo")
   void shouldUploadProfilePhoto() throws Exception {
     when(photoService.addProfilePhoto(userId, file)).thenReturn(photoUrl);
@@ -58,6 +60,7 @@ class PhotoControllerTest {
   }
 
   @Test
+  @WithMockUser(username = "user123")
   @DisplayName("Should upload cover photo")
   void shouldUploadCoverPhoto() throws Exception {
     when(photoService.addCoverPhoto(userId, file)).thenReturn(photoUrl);
@@ -70,6 +73,7 @@ class PhotoControllerTest {
   }
 
   @Test
+  @WithMockUser(username = "user123")
   @DisplayName("Should delete profile photo")
   void shouldDeleteProfilePhoto() throws Exception {
     doNothing().when(photoService).deleteProfilePhoto(userId);
@@ -79,6 +83,7 @@ class PhotoControllerTest {
   }
 
   @Test
+  @WithMockUser(username = "user123")
   @DisplayName("Should delete cover photo")
   void shouldDeleteCoverPhoto() throws Exception {
     doNothing().when(photoService).deleteCoverPhoto(userId);

--- a/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/SwapControllerTest.java
+++ b/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/SwapControllerTest.java
@@ -109,6 +109,7 @@ class SwapControllerTest {
     when(swapService.createSwapRequest(any())).thenReturn(entity);
 
     mockMvc.perform(post(API_PATH)
+        .with(withUser("user1"))
         .contentType(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isCreated())
@@ -133,6 +134,7 @@ class SwapControllerTest {
     CreateSwapRequest request = new CreateSwapRequest(); // All fields null
 
     mockMvc.perform(post(API_PATH)
+        .with(withUser("user1"))
         .contentType(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isBadRequest());
@@ -153,6 +155,7 @@ class SwapControllerTest {
     request.setSwapOffer(offer);
 
     mockMvc.perform(post(API_PATH)
+        .with(withUser("user1"))
         .contentType(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isBadRequest());
@@ -170,6 +173,7 @@ class SwapControllerTest {
     request.setSwapOffer(new CreateSwapRequest.SwapOfferRequest()); // both null
 
     mockMvc.perform(post(API_PATH)
+        .with(withUser("user1"))
         .contentType(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isBadRequest());

--- a/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/UserControllerTest.java
+++ b/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/UserControllerTest.java
@@ -24,6 +24,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -89,8 +90,8 @@ public class UserControllerTest {
     createUserRequest.setFirstName("Test");
     createUserRequest.setLastName("User");
     createUserRequest.setEmail("test@example.com");
-    createUserRequest.setPassword("password");
-    createUserRequest.setConfirmPassword("password");
+    createUserRequest.setPassword("Password1!");
+    createUserRequest.setConfirmPassword("Password1!");
 
     when(jwtUtil.generateUserToken(any(), any())).thenReturn("mock-user-token");
     when(jwtUtil.generateUserRefreshToken(any(), any())).thenReturn("mock-user-refresh-token");
@@ -129,6 +130,7 @@ public class UserControllerTest {
   }
 
   @Test
+  @WithMockUser(username = "1")
   @DisplayName("Should update user")
   void shouldUpdateUser() throws Exception {
     UpdateUserRequest request = getUserUpdateRequest();
@@ -167,6 +169,7 @@ public class UserControllerTest {
   }
 
   @Test
+  @WithMockUser(username = "1")
   @DisplayName("Should delete user by ID")
   void shouldDeleteUser() throws Exception {
     mockMvc.perform(delete(API_BASE + "/1")
@@ -179,7 +182,7 @@ public class UserControllerTest {
   void shouldLogin() throws Exception {
     AuthenticateUserRequest request = new AuthenticateUserRequest();
     request.setEmail("test@example.com");
-    request.setPassword("password");
+    request.setPassword("Password1!");
 
     when(userService.verifyLogin(any(User.class))).thenReturn(user);
 
@@ -198,9 +201,10 @@ public class UserControllerTest {
   void shouldChangePassword() throws Exception {
     ChangePasswordRequest request = new ChangePasswordRequest();
     request.setCurrentPassword("currentPassword");
-    request.setNewPassword("newPassword");
-    request.setConfirmPassword("newPassword");
+    request.setNewPassword("newPassword1!");
+    request.setConfirmPassword("newPassword1!");
 
+    Mockito.doNothing().when(userService).verifyCurrentPassword(any());
     when(userService.changePassword(any())).thenReturn("test@example.com");
 
     mockMvc.perform(post(API_BASE + "/change-password/test@example.com")
@@ -215,9 +219,12 @@ public class UserControllerTest {
   @DisplayName("Should reset user password")
   void shouldResetPassword() throws Exception {
     ResetPasswordRequest request = new ResetPasswordRequest();
-    request.setNewPassword("newPassword");
-    request.setConfirmPassword("newPassword");
+    request.setNewPassword("newPassword1!");
+    request.setConfirmPassword("newPassword1!");
+    request.setResetToken("valid-reset-token");
 
+    when(jwtUtil.validatePasswordResetToken("valid-reset-token")).thenReturn(true);
+    when(jwtUtil.extractEmailFromResetToken("valid-reset-token")).thenReturn("test@example.com");
     when(userService.changePassword(any())).thenReturn("test@example.com");
 
     mockMvc.perform(post(API_BASE + "/reset-password/test@example.com")
@@ -344,7 +351,7 @@ public class UserControllerTest {
   @Test
   @DisplayName("Should return 400 when password and confirm password mismatch")
   void shouldReturnBadRequestWhenPasswordMismatch() throws Exception {
-    createUserRequest.setConfirmPassword("differentPassword");
+    createUserRequest.setConfirmPassword("Different1!");
 
     mockMvc.perform(post(API_BASE + "/signup")
         .contentType(MediaType.APPLICATION_JSON)
@@ -468,6 +475,7 @@ public class UserControllerTest {
   }
 
   @Test
+  @WithMockUser(username = "1")
   @DisplayName("Should return 404 when user does not exist")
   void shouldReturnNotFoundWhenUserDoesNotExist() throws Exception {
     UpdateUserRequest request = getUserUpdateRequest();
@@ -496,7 +504,7 @@ public class UserControllerTest {
   void shouldReturnUnauthorizedWhenPasswordIsIncorrect() throws Exception {
     AuthenticateUserRequest request = new AuthenticateUserRequest();
     request.setEmail("test@example.com");
-    request.setPassword("wrongPassword");
+    request.setPassword("wrongPassword1!");
 
     when(userService.verifyLogin(any(User.class))).thenThrow(new InvalidCredentials());
 
@@ -512,7 +520,7 @@ public class UserControllerTest {
   void shouldReturnNotFoundWhenEmailIsNotRegistered() throws Exception {
     AuthenticateUserRequest request = new AuthenticateUserRequest();
     request.setEmail("nonexistent@example.com");
-    request.setPassword("password");
+    request.setPassword("Password1!");
 
     when(userService.verifyLogin(any(User.class))).thenThrow(new UserNotFoundException());
 
@@ -528,8 +536,8 @@ public class UserControllerTest {
   void shouldReturnBadRequestWhenPasswordsDoNotMatch() throws Exception {
     ChangePasswordRequest request = new ChangePasswordRequest();
     request.setCurrentPassword("currentPassword");
-    request.setNewPassword("newPassword");
-    request.setConfirmPassword("differentPassword");
+    request.setNewPassword("newPassword1!");
+    request.setConfirmPassword("Different1!");
 
     mockMvc.perform(post(API_BASE + "/change-password/test@example.com")
         .contentType(MediaType.APPLICATION_JSON)
@@ -657,7 +665,7 @@ public class UserControllerTest {
         .contentType(MediaType.APPLICATION_JSON)
         .content("{\"idToken\":\"" + idTokenString + "\"}"))
         .andExpect(status().isUnauthorized())
-        .andExpect(content().string("Invalid token"));
+        .andExpect(jsonPath("$.error.code").value("invalidGoogleToken"));
   }
 
   @Test
@@ -670,6 +678,6 @@ public class UserControllerTest {
         .contentType(MediaType.APPLICATION_JSON)
         .content("{\"idToken\":\"" + idTokenString + "\"}"))
         .andExpect(status().isUnauthorized())
-        .andExpect(content().string("Invalid ID token"));
+        .andExpect(jsonPath("$.error.code").value("invalidIdToken"));
   }
 }

--- a/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/UserControllerTest.java
+++ b/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/UserControllerTest.java
@@ -75,6 +75,9 @@ public class UserControllerTest {
   @MockitoBean
   private JwtUtil jwtUtil;
 
+  @MockitoBean
+  private com.kirjaswappi.backend.common.service.RateLimiterService rateLimiterService;
+
   private User user;
 
   private CreateUserRequest createUserRequest;

--- a/src/test/java/com/kirjaswappi/backend/integration/BookApiIntegrationTest.java
+++ b/src/test/java/com/kirjaswappi/backend/integration/BookApiIntegrationTest.java
@@ -22,6 +22,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -354,14 +355,13 @@ class BookApiIntegrationTest {
     }
 
     @Test
-    @DisplayName("Should return 400 for non-existent book")
+    @DisplayName("Should return 404 for non-existent book")
     void shouldReturn404ForNonExistentBook() throws Exception {
-      // BookNotFoundException extends BusinessException which returns 400
       when(bookService.getBookById("nonexistent-id"))
           .thenThrow(new BookNotFoundException());
 
       mockMvc.perform(get(API_BASE + "/nonexistent-id"))
-          .andExpect(status().isBadRequest());
+          .andExpect(status().isNotFound());
     }
 
     @Test
@@ -526,9 +526,11 @@ class BookApiIntegrationTest {
   class UpdateBookTests {
 
     @Test
+    @WithMockUser(username = "user-123")
     @DisplayName("Should update book successfully")
     void shouldUpdateBookSuccessfully() throws Exception {
       Book book = createTestBook("book-1", "Updated Title", "Updated Author");
+      when(bookService.getBookById("book-1")).thenReturn(book);
       when(bookService.updateBook(any())).thenReturn(book);
 
       String swapCondition = """
@@ -590,9 +592,11 @@ class BookApiIntegrationTest {
     }
 
     @Test
+    @WithMockUser(username = "user-123")
     @DisplayName("Should update book with location data as JSON string")
     void shouldUpdateBookWithLocationAsJsonString() throws Exception {
       Book book = createTestBookWithLocation("book-1", "Updated Book", "Helsinki", "Finland");
+      when(bookService.getBookById("book-1")).thenReturn(book);
       when(bookService.updateBook(any())).thenReturn(book);
 
       String swapCondition = """
@@ -640,8 +644,12 @@ class BookApiIntegrationTest {
   class DeleteBookTests {
 
     @Test
+    @WithMockUser(username = "user-123")
     @DisplayName("Should delete book successfully")
     void shouldDeleteBookSuccessfully() throws Exception {
+      Book book = createTestBook("book-1", "Test Book", "Test Author");
+      when(bookService.getBookById("book-1")).thenReturn(book);
+
       mockMvc.perform(delete(API_BASE + "/book-1"))
           .andExpect(status().isNoContent());
     }

--- a/src/test/java/com/kirjaswappi/backend/integration/BookApiIntegrationTest.java
+++ b/src/test/java/com/kirjaswappi/backend/integration/BookApiIntegrationTest.java
@@ -522,6 +522,35 @@ class BookApiIntegrationTest {
   }
 
   @Nested
+  @DisplayName("Map Bounds Query Tests")
+  class MapBoundsQueryTests {
+
+    @Test
+    @DisplayName("Should return books in map bounds")
+    void shouldReturnBooksInMapBounds() throws Exception {
+      Book book = createTestBookWithLocation("book-1", "Map Book", "Helsinki", "Finland");
+      when(bookService.getAllBooksByFilter(any(), any(Pageable.class)))
+          .thenReturn(new PageImpl<>(List.of(book), PageRequest.of(0, 100), 1));
+
+      mockMvc.perform(get(API_BASE + "/map")
+          .param("city", "Helsinki"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$._embedded.books.length()").value(1));
+    }
+
+    @Test
+    @DisplayName("Should return empty results when no books in bounds")
+    void shouldReturnEmptyResultsWhenNoBooksInBounds() throws Exception {
+      when(bookService.getAllBooksByFilter(any(), any(Pageable.class)))
+          .thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 100), 0));
+
+      mockMvc.perform(get(API_BASE + "/map"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.page.totalElements").value(0));
+    }
+  }
+
+  @Nested
   @DisplayName("Update Book Tests")
   class UpdateBookTests {
 

--- a/src/test/java/com/kirjaswappi/backend/integration/BookApiIntegrationTest.java
+++ b/src/test/java/com/kirjaswappi/backend/integration/BookApiIntegrationTest.java
@@ -533,7 +533,10 @@ class BookApiIntegrationTest {
           .thenReturn(new PageImpl<>(List.of(book), PageRequest.of(0, 100), 1));
 
       mockMvc.perform(get(API_BASE + "/map")
-          .param("city", "Helsinki"))
+          .param("north", "61.0")
+          .param("south", "59.0")
+          .param("east", "26.0")
+          .param("west", "23.0"))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$._embedded.books.length()").value(1));
     }
@@ -544,9 +547,21 @@ class BookApiIntegrationTest {
       when(bookService.getAllBooksByFilter(any(), any(Pageable.class)))
           .thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 100), 0));
 
-      mockMvc.perform(get(API_BASE + "/map"))
+      mockMvc.perform(get(API_BASE + "/map")
+          .param("north", "61.0")
+          .param("south", "59.0")
+          .param("east", "26.0")
+          .param("west", "23.0"))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.page.totalElements").value(0));
+    }
+
+    @Test
+    @DisplayName("Should return 400 when map bounds are incomplete")
+    void shouldReturn400WhenMapBoundsIncomplete() throws Exception {
+      mockMvc.perform(get(API_BASE + "/map")
+          .param("north", "61.0"))
+          .andExpect(status().isBadRequest());
     }
   }
 

--- a/src/test/java/com/kirjaswappi/backend/integration/CityApiIntegrationTest.java
+++ b/src/test/java/com/kirjaswappi/backend/integration/CityApiIntegrationTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025 KirjaSwappi or KirjaSwappi affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+package com.kirjaswappi.backend.integration;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.kirjaswappi.backend.common.http.controllers.mockMvc.config.CustomMockMvcConfiguration;
+import com.kirjaswappi.backend.http.controllers.CityController;
+import com.kirjaswappi.backend.service.CityService;
+import com.kirjaswappi.backend.service.entities.City;
+
+@WebMvcTest(CityController.class)
+@Import(CustomMockMvcConfiguration.class)
+class CityApiIntegrationTest {
+
+  private static final String API_PATH = "/api/v1/cities";
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private CityService cityService;
+
+  @Test
+  @DisplayName("Should return all cities")
+  void shouldReturnAllCities() throws Exception {
+    when(cityService.getCities()).thenReturn(List.of(new City("Helsinki"), new City("Tampere")));
+
+    mockMvc.perform(get(API_PATH))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.length()").value(2))
+        .andExpect(jsonPath("$[0].name").value("Helsinki"))
+        .andExpect(jsonPath("$[1].name").value("Tampere"));
+  }
+
+  @Test
+  @DisplayName("Should return empty list when no cities")
+  void shouldReturnEmptyListWhenNoCities() throws Exception {
+    when(cityService.getCities()).thenReturn(List.of());
+
+    mockMvc.perform(get(API_PATH))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.length()").value(0));
+  }
+}

--- a/src/test/java/com/kirjaswappi/backend/integration/FormApiIntegrationTest.java
+++ b/src/test/java/com/kirjaswappi/backend/integration/FormApiIntegrationTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2025 KirjaSwappi or KirjaSwappi affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+package com.kirjaswappi.backend.integration;
+
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kirjaswappi.backend.common.http.controllers.mockMvc.config.CustomMockMvcConfiguration;
+import com.kirjaswappi.backend.common.service.EmailService;
+import com.kirjaswappi.backend.http.controllers.FormController;
+import com.kirjaswappi.backend.http.dtos.requests.FormSubmissionRequest;
+
+@WebMvcTest(FormController.class)
+@Import(CustomMockMvcConfiguration.class)
+class FormApiIntegrationTest {
+
+  private static final String API_PATH = "/api/v1/forms";
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockitoBean
+  private EmailService emailService;
+
+  private FormSubmissionRequest validRequest() {
+    FormSubmissionRequest request = new FormSubmissionRequest();
+    request.setName("John Doe");
+    request.setEmail("john@example.com");
+    request.setMessage("I would like to get in touch.");
+    return request;
+  }
+
+  @Nested
+  @DisplayName("Form Type Tests")
+  class FormTypeTests {
+
+    @Test
+    @DisplayName("Should submit contact form")
+    void shouldSubmitContactForm() throws Exception {
+      doNothing().when(emailService).sendFormSubmission(
+          org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(),
+          org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(),
+          org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+
+      mockMvc.perform(post(API_PATH + "/contact")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(validRequest())))
+          .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Should submit collaboration form")
+    void shouldSubmitCollaborationForm() throws Exception {
+      doNothing().when(emailService).sendFormSubmission(
+          org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(),
+          org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(),
+          org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+
+      mockMvc.perform(post(API_PATH + "/collaboration")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(validRequest())))
+          .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Should submit donation form")
+    void shouldSubmitDonationForm() throws Exception {
+      doNothing().when(emailService).sendFormSubmission(
+          org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(),
+          org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(),
+          org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+
+      mockMvc.perform(post(API_PATH + "/donation")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(validRequest())))
+          .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Should submit feedback form")
+    void shouldSubmitFeedbackForm() throws Exception {
+      doNothing().when(emailService).sendFormSubmission(
+          org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(),
+          org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(),
+          org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+
+      mockMvc.perform(post(API_PATH + "/feedback")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(validRequest())))
+          .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Should submit volunteer form")
+    void shouldSubmitVolunteerForm() throws Exception {
+      doNothing().when(emailService).sendFormSubmission(
+          org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(),
+          org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(),
+          org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+
+      mockMvc.perform(post(API_PATH + "/volunteer")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(validRequest())))
+          .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Should return 400 for invalid form type")
+    void shouldReturn400ForInvalidFormType() throws Exception {
+      mockMvc.perform(post(API_PATH + "/invalid")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(validRequest())))
+          .andExpect(status().isBadRequest());
+    }
+  }
+
+  @Nested
+  @DisplayName("Validation Tests")
+  class ValidationTests {
+
+    @Test
+    @DisplayName("Should return 400 when name is missing")
+    void shouldReturn400WhenNameMissing() throws Exception {
+      FormSubmissionRequest request = validRequest();
+      request.setName(null);
+
+      mockMvc.perform(post(API_PATH + "/contact")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Should return 400 when email is invalid")
+    void shouldReturn400WhenEmailInvalid() throws Exception {
+      FormSubmissionRequest request = validRequest();
+      request.setEmail("not-an-email");
+
+      mockMvc.perform(post(API_PATH + "/contact")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Should return 400 when email is missing")
+    void shouldReturn400WhenEmailMissing() throws Exception {
+      FormSubmissionRequest request = validRequest();
+      request.setEmail(null);
+
+      mockMvc.perform(post(API_PATH + "/contact")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Should return 400 when message is missing")
+    void shouldReturn400WhenMessageMissing() throws Exception {
+      FormSubmissionRequest request = validRequest();
+      request.setMessage(null);
+
+      mockMvc.perform(post(API_PATH + "/contact")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isBadRequest());
+    }
+  }
+}

--- a/src/test/java/com/kirjaswappi/backend/integration/GenreApiIntegrationTest.java
+++ b/src/test/java/com/kirjaswappi/backend/integration/GenreApiIntegrationTest.java
@@ -303,6 +303,25 @@ class GenreApiIntegrationTest {
         .andExpect(jsonPath("$.parentGenres['Arts & Crafts']").exists());
   }
 
+  // Helper method to create and save a genre with auto-generated ID
+  private GenreDao createGenreAutoId(String name, GenreDao parent) {
+    GenreDao genre = GenreDao.builder()
+        .name(name)
+        .parent(parent)
+        .build();
+    GenreDao saved = genreRepository.save(genre);
+
+    // Clear caches because direct repository save bypasses service eviction
+    if (cacheManager.getCache("genres") != null) {
+      cacheManager.getCache("genres").clear();
+    }
+    if (cacheManager.getCache("nested_genres") != null) {
+      cacheManager.getCache("nested_genres").clear();
+    }
+
+    return saved;
+  }
+
   // Helper method to create and save a genre
   private GenreDao createGenre(String id, String name, GenreDao parent) {
     GenreDao genre = GenreDao.builder()
@@ -623,9 +642,9 @@ class GenreApiIntegrationTest {
     @Test
     @DisplayName("Should delete genre successfully")
     void shouldDeleteGenreSuccessfully() throws Exception {
-      GenreDao genre = createGenre("delete-test-id", "Fiction", null);
+      GenreDao genre = createGenreAutoId("Fiction", null);
 
-      mockMvc.perform(delete("/api/v1/genres/delete-test-id"))
+      mockMvc.perform(delete("/api/v1/genres/" + genre.id()))
           .andExpect(status().isNoContent());
 
       // Verify genre is deleted by trying to get it via nested response
@@ -637,28 +656,28 @@ class GenreApiIntegrationTest {
     @Test
     @DisplayName("Should delete parent genre with child genres")
     void shouldDeleteParentGenreWithChildGenres() throws Exception {
-      GenreDao parent = createGenre("parent-to-delete", "Fiction", null);
-      GenreDao child1 = createGenre("child-1", "Science Fiction", parent);
-      GenreDao child2 = createGenre("child-2", "Fantasy", parent);
+      GenreDao parent = createGenreAutoId("Fiction", null);
+      GenreDao child1 = createGenreAutoId("Science Fiction", parent);
+      GenreDao child2 = createGenreAutoId("Fantasy", parent);
 
-      mockMvc.perform(delete("/api/v1/genres/parent-to-delete"))
+      mockMvc.perform(delete("/api/v1/genres/" + parent.id()))
           .andExpect(status().isNoContent());
     }
 
     @Test
     @DisplayName("Should delete child genre leaving parent intact")
     void shouldDeleteChildGenreLeavingParentIntact() throws Exception {
-      GenreDao parent = createGenre("parent-intact", "Fiction", null);
-      GenreDao child = createGenre("child-to-delete", "Science Fiction", parent);
+      GenreDao parent = createGenreAutoId("Fiction", null);
+      GenreDao child = createGenreAutoId("Science Fiction", parent);
 
-      mockMvc.perform(delete("/api/v1/genres/child-to-delete"))
+      mockMvc.perform(delete("/api/v1/genres/" + child.id()))
           .andExpect(status().isNoContent());
 
       // Verify parent still exists
       mockMvc.perform(get("/api/v1/genres"))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.parentGenres.Fiction").exists())
-          .andExpect(jsonPath("$.parentGenres.Fiction.id").value("parent-intact"));
+          .andExpect(jsonPath("$.parentGenres.Fiction.id").value(parent.id()));
     }
 
     @Test
@@ -669,28 +688,28 @@ class GenreApiIntegrationTest {
     }
 
     @Test
-    @DisplayName("Should handle deleting genre with special characters in id")
+    @DisplayName("Should handle deleting genre with auto-generated id")
     void shouldHandleDeletingGenreWithSpecialId() throws Exception {
-      GenreDao genre = createGenre("special-id-123", "Test Genre", null);
+      GenreDao genre = createGenreAutoId("Test Genre", null);
 
-      mockMvc.perform(delete("/api/v1/genres/special-id-123"))
+      mockMvc.perform(delete("/api/v1/genres/" + genre.id()))
           .andExpect(status().isNoContent());
     }
 
     @Test
     @DisplayName("Should delete multiple genres in sequence")
     void shouldDeleteMultipleGenresInSequence() throws Exception {
-      GenreDao genre1 = createGenre("seq-delete-1", "Genre 1", null);
-      GenreDao genre2 = createGenre("seq-delete-2", "Genre 2", null);
-      GenreDao genre3 = createGenre("seq-delete-3", "Genre 3", null);
+      GenreDao genre1 = createGenreAutoId("Genre 1", null);
+      GenreDao genre2 = createGenreAutoId("Genre 2", null);
+      GenreDao genre3 = createGenreAutoId("Genre 3", null);
 
-      mockMvc.perform(delete("/api/v1/genres/seq-delete-1"))
+      mockMvc.perform(delete("/api/v1/genres/" + genre1.id()))
           .andExpect(status().isNoContent());
 
-      mockMvc.perform(delete("/api/v1/genres/seq-delete-2"))
+      mockMvc.perform(delete("/api/v1/genres/" + genre2.id()))
           .andExpect(status().isNoContent());
 
-      mockMvc.perform(delete("/api/v1/genres/seq-delete-3"))
+      mockMvc.perform(delete("/api/v1/genres/" + genre3.id()))
           .andExpect(status().isNoContent());
 
       // Verify all are deleted

--- a/src/test/java/com/kirjaswappi/backend/integration/InboxApiIntegrationTest.java
+++ b/src/test/java/com/kirjaswappi/backend/integration/InboxApiIntegrationTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -101,7 +102,8 @@ class InboxApiIntegrationTest {
           createTestSwapRequest("request-2", "user-3", userId, SwapStatus.ACCEPTED));
 
       when(inboxService.getUnifiedInbox(userId, null, null)).thenReturn(requests);
-      when(inboxService.getUnreadMessageCount(eq(userId), anyString())).thenReturn(0L);
+      when(inboxService.getBatchUnreadMessageCounts(eq(userId), anyList()))
+          .thenReturn(Map.of("request-1", 0L, "request-2", 0L));
       when(inboxService.isInboxItemUnread(any(), eq(userId))).thenReturn(false);
 
       mockMvc.perform(get(API_BASE)
@@ -132,7 +134,8 @@ class InboxApiIntegrationTest {
           createTestSwapRequest("request-1", userId, "user-2", SwapStatus.PENDING));
 
       when(inboxService.getUnifiedInbox(userId, "Pending", null)).thenReturn(requests);
-      when(inboxService.getUnreadMessageCount(eq(userId), anyString())).thenReturn(0L);
+      when(inboxService.getBatchUnreadMessageCounts(eq(userId), anyList()))
+          .thenReturn(Map.of("request-1", 0L));
       when(inboxService.isInboxItemUnread(any(), eq(userId))).thenReturn(false);
 
       mockMvc.perform(get(API_BASE)
@@ -151,7 +154,8 @@ class InboxApiIntegrationTest {
           createTestSwapRequest("request-1", userId, "user-2", SwapStatus.PENDING));
 
       when(inboxService.getUnifiedInbox(userId, null, "date")).thenReturn(requests);
-      when(inboxService.getUnreadMessageCount(eq(userId), anyString())).thenReturn(0L);
+      when(inboxService.getBatchUnreadMessageCounts(eq(userId), anyList()))
+          .thenReturn(Map.of("request-1", 0L));
       when(inboxService.isInboxItemUnread(any(), eq(userId))).thenReturn(false);
 
       mockMvc.perform(get(API_BASE)
@@ -184,7 +188,8 @@ class InboxApiIntegrationTest {
           createTestSwapRequest("request-1", userId, "user-2", SwapStatus.PENDING));
 
       when(inboxService.getUnifiedInbox(userId, null, null)).thenReturn(requests);
-      when(inboxService.getUnreadMessageCount(userId, "request-1")).thenReturn(5L);
+      when(inboxService.getBatchUnreadMessageCounts(eq(userId), anyList()))
+          .thenReturn(Map.of("request-1", 5L));
       when(inboxService.isInboxItemUnread(any(), eq(userId))).thenReturn(true);
 
       mockMvc.perform(get(API_BASE)
@@ -203,7 +208,8 @@ class InboxApiIntegrationTest {
           createTestSwapRequest("request-1", userId, "user-2", SwapStatus.PENDING));
 
       when(inboxService.getUnifiedInbox(userId, null, null)).thenReturn(requests);
-      when(inboxService.getUnreadMessageCount(eq(userId), anyString())).thenReturn(0L);
+      when(inboxService.getBatchUnreadMessageCounts(eq(userId), anyList()))
+          .thenReturn(Map.of("request-1", 0L));
       when(inboxService.isInboxItemUnread(any(), eq(userId))).thenReturn(false);
 
       mockMvc.perform(get(API_BASE)
@@ -220,7 +226,8 @@ class InboxApiIntegrationTest {
           createTestSwapRequest("request-1", "user-1", userId, SwapStatus.PENDING));
 
       when(inboxService.getUnifiedInbox(userId, null, null)).thenReturn(requests);
-      when(inboxService.getUnreadMessageCount(eq(userId), anyString())).thenReturn(0L);
+      when(inboxService.getBatchUnreadMessageCounts(eq(userId), anyList()))
+          .thenReturn(Map.of("request-1", 0L));
       when(inboxService.isInboxItemUnread(any(), eq(userId))).thenReturn(false);
 
       mockMvc.perform(get(API_BASE)

--- a/src/test/java/com/kirjaswappi/backend/integration/OtpApiIntegrationTest.java
+++ b/src/test/java/com/kirjaswappi/backend/integration/OtpApiIntegrationTest.java
@@ -43,6 +43,9 @@ class OtpApiIntegrationTest {
   @MockitoBean
   private OTPService otpService;
 
+  @MockitoBean
+  private com.kirjaswappi.backend.common.utils.JwtUtil jwtUtil;
+
   @Autowired
   private ObjectMapper objectMapper;
 

--- a/src/test/java/com/kirjaswappi/backend/integration/PhotoApiIntegrationTest.java
+++ b/src/test/java/com/kirjaswappi/backend/integration/PhotoApiIntegrationTest.java
@@ -21,6 +21,7 @@ import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -65,6 +66,7 @@ class PhotoApiIntegrationTest {
   class ProfilePhotoTests {
 
     @Test
+    @WithMockUser(username = "user-123")
     @DisplayName("Should upload profile photo successfully")
     void shouldUploadProfilePhoto() throws Exception {
       when(photoService.addProfilePhoto(anyString(), any())).thenReturn(photoUrl);
@@ -93,6 +95,7 @@ class PhotoApiIntegrationTest {
     }
 
     @Test
+    @WithMockUser(username = "user-123")
     @DisplayName("Should delete profile photo successfully")
     void shouldDeleteProfilePhoto() throws Exception {
       doNothing().when(photoService).deleteProfilePhoto(userId);
@@ -137,6 +140,7 @@ class PhotoApiIntegrationTest {
   class CoverPhotoTests {
 
     @Test
+    @WithMockUser(username = "user-123")
     @DisplayName("Should upload cover photo successfully")
     void shouldUploadCoverPhoto() throws Exception {
       when(photoService.addCoverPhoto(anyString(), any())).thenReturn(photoUrl);
@@ -157,6 +161,7 @@ class PhotoApiIntegrationTest {
     }
 
     @Test
+    @WithMockUser(username = "user-123")
     @DisplayName("Should delete cover photo successfully")
     void shouldDeleteCoverPhoto() throws Exception {
       doNothing().when(photoService).deleteCoverPhoto(userId);
@@ -260,6 +265,7 @@ class PhotoApiIntegrationTest {
   class ErrorHandlingTests {
 
     @Test
+    @WithMockUser(username = "nonexistent")
     @DisplayName("Should handle service exception for profile photo upload")
     void shouldHandleServiceExceptionForProfilePhotoUpload() throws Exception {
       when(photoService.addProfilePhoto(anyString(), any()))
@@ -272,6 +278,7 @@ class PhotoApiIntegrationTest {
     }
 
     @Test
+    @WithMockUser(username = "nonexistent")
     @DisplayName("Should handle service exception for cover photo upload")
     void shouldHandleServiceExceptionForCoverPhotoUpload() throws Exception {
       when(photoService.addCoverPhoto(anyString(), any()))

--- a/src/test/java/com/kirjaswappi/backend/integration/SwapRequestApiIntegrationTest.java
+++ b/src/test/java/com/kirjaswappi/backend/integration/SwapRequestApiIntegrationTest.java
@@ -122,6 +122,7 @@ class SwapRequestApiIntegrationTest {
       request.setSwapOffer(offer);
 
       mockMvc.perform(post(API_BASE)
+          .with(withUser("sender-1"))
           .contentType(MediaType.APPLICATION_JSON)
           .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isCreated());
@@ -149,6 +150,7 @@ class SwapRequestApiIntegrationTest {
       request.setSwapOffer(offer);
 
       mockMvc.perform(post(API_BASE)
+          .with(withUser("sender-1"))
           .contentType(MediaType.APPLICATION_JSON)
           .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isCreated());
@@ -176,6 +178,7 @@ class SwapRequestApiIntegrationTest {
       request.setSwapOffer(offer);
 
       mockMvc.perform(post(API_BASE)
+          .with(withUser("sender-1"))
           .contentType(MediaType.APPLICATION_JSON)
           .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isCreated());
@@ -188,6 +191,7 @@ class SwapRequestApiIntegrationTest {
       // Missing all required fields
 
       mockMvc.perform(post(API_BASE)
+          .with(withUser("sender-1"))
           .contentType(MediaType.APPLICATION_JSON)
           .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isBadRequest());
@@ -208,6 +212,7 @@ class SwapRequestApiIntegrationTest {
       request.setSwapOffer(offer);
 
       mockMvc.perform(post(API_BASE)
+          .with(withUser("sender-1"))
           .contentType(MediaType.APPLICATION_JSON)
           .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isBadRequest());
@@ -224,6 +229,7 @@ class SwapRequestApiIntegrationTest {
       request.setSwapOffer(new CreateSwapRequest.SwapOfferRequest()); // Empty offer
 
       mockMvc.perform(post(API_BASE)
+          .with(withUser("sender-1"))
           .contentType(MediaType.APPLICATION_JSON)
           .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isBadRequest());

--- a/src/test/java/com/kirjaswappi/backend/integration/UserApiIntegrationTest.java
+++ b/src/test/java/com/kirjaswappi/backend/integration/UserApiIntegrationTest.java
@@ -15,10 +15,11 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -42,7 +43,6 @@ import com.kirjaswappi.backend.jpa.repositories.UserRepository;
 @SpringBootTest
 @Import(TestContainersConfig.class)
 @ActiveProfiles("test")
-@AutoConfigureMockMvc
 class UserApiIntegrationTest {
 
   private static final String API_BASE = "/api/v1/users";
@@ -69,7 +69,8 @@ class UserApiIntegrationTest {
 
   @BeforeEach
   void setUp() {
-    mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+    mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+        .build();
 
     // Clean up existing data
     bookRepository.deleteAll();
@@ -419,13 +420,19 @@ class UserApiIntegrationTest {
       request.setAboutMe("I love books!");
       request.setFavGenres(List.of());
 
-      mockMvc.perform(put(API_BASE + "/" + user.id())
-          .contentType(MediaType.APPLICATION_JSON)
-          .content(objectMapper.writeValueAsString(request)))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$.firstName").value("Updated"))
-          .andExpect(jsonPath("$.city").value("Helsinki"))
-          .andExpect(jsonPath("$.aboutMe").value("I love books!"));
+      var auth = new UsernamePasswordAuthenticationToken(user.id(), null, List.of());
+      SecurityContextHolder.getContext().setAuthentication(auth);
+      try {
+        mockMvc.perform(put(API_BASE + "/" + user.id())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.firstName").value("Updated"))
+            .andExpect(jsonPath("$.city").value("Helsinki"))
+            .andExpect(jsonPath("$.aboutMe").value("I love books!"));
+      } finally {
+        SecurityContextHolder.clearContext();
+      }
     }
 
     @Test
@@ -456,10 +463,16 @@ class UserApiIntegrationTest {
       request.setLastName("User");
       request.setFavGenres(List.of());
 
-      mockMvc.perform(put(API_BASE + "/" + nonExistentId)
-          .contentType(MediaType.APPLICATION_JSON)
-          .content(objectMapper.writeValueAsString(request)))
-          .andExpect(status().isNotFound());
+      var auth = new UsernamePasswordAuthenticationToken(nonExistentId, null, List.of());
+      SecurityContextHolder.getContext().setAuthentication(auth);
+      try {
+        mockMvc.perform(put(API_BASE + "/" + nonExistentId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isNotFound());
+      } finally {
+        SecurityContextHolder.clearContext();
+      }
     }
   }
 
@@ -472,12 +485,18 @@ class UserApiIntegrationTest {
     void shouldDeleteUserSuccessfully() throws Exception {
       UserDao user = createTestUser("Delete", "Me", "delete@example.com");
 
-      mockMvc.perform(delete(API_BASE + "/" + user.id()))
-          .andExpect(status().isNoContent());
+      var auth = new UsernamePasswordAuthenticationToken(user.id(), null, List.of());
+      SecurityContextHolder.getContext().setAuthentication(auth);
+      try {
+        mockMvc.perform(delete(API_BASE + "/" + user.id()))
+            .andExpect(status().isNoContent());
 
-      // Verify user is deleted
-      mockMvc.perform(get(API_BASE + "/" + user.id()))
-          .andExpect(status().isNotFound());
+        // Verify user is deleted
+        mockMvc.perform(get(API_BASE + "/" + user.id()))
+            .andExpect(status().isNotFound());
+      } finally {
+        SecurityContextHolder.clearContext();
+      }
     }
   }
 

--- a/src/test/java/com/kirjaswappi/backend/integration/UserInteractionApiIntegrationTest.java
+++ b/src/test/java/com/kirjaswappi/backend/integration/UserInteractionApiIntegrationTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2025 KirjaSwappi or KirjaSwappi affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+package com.kirjaswappi.backend.integration;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kirjaswappi.backend.common.http.controllers.mockMvc.config.CustomMockMvcConfiguration;
+import com.kirjaswappi.backend.http.controllers.UserInteractionController;
+import com.kirjaswappi.backend.http.dtos.requests.CreateReportRequest;
+import com.kirjaswappi.backend.service.ReportService;
+import com.kirjaswappi.backend.service.UserService;
+import com.kirjaswappi.backend.service.entities.Report;
+import com.kirjaswappi.backend.service.exceptions.UserNotFoundException;
+
+@WebMvcTest(UserInteractionController.class)
+@Import(CustomMockMvcConfiguration.class)
+class UserInteractionApiIntegrationTest {
+
+  private static final String USERS_PATH = "/api/v1/users";
+  private static final String REPORTS_PATH = "/api/v1/reports";
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockitoBean
+  private UserService userService;
+
+  @MockitoBean
+  private ReportService reportService;
+
+  @Nested
+  @DisplayName("Block/Unblock Tests")
+  class BlockTests {
+
+    @Test
+    @DisplayName("Should block user successfully")
+    void shouldBlockUserSuccessfully() throws Exception {
+      doNothing().when(userService).blockUser("user-1", "user-2");
+
+      mockMvc.perform(post(USERS_PATH + "/user-2/block")
+          .with(withUser("user-1")))
+          .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("Should return 401 when blocking without auth")
+    void shouldReturn401WhenBlockingWithoutAuth() throws Exception {
+      mockMvc.perform(post(USERS_PATH + "/user-2/block"))
+          .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Should return 404 when blocking non-existent user")
+    void shouldReturn404WhenBlockingNonExistentUser() throws Exception {
+      org.mockito.Mockito.doThrow(new UserNotFoundException())
+          .when(userService).blockUser("user-1", "nonexistent");
+
+      mockMvc.perform(post(USERS_PATH + "/nonexistent/block")
+          .with(withUser("user-1")))
+          .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Should unblock user successfully")
+    void shouldUnblockUserSuccessfully() throws Exception {
+      doNothing().when(userService).unblockUser("user-1", "user-2");
+
+      mockMvc.perform(delete(USERS_PATH + "/user-2/block")
+          .with(withUser("user-1")))
+          .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("Should return 401 when unblocking without auth")
+    void shouldReturn401WhenUnblockingWithoutAuth() throws Exception {
+      mockMvc.perform(delete(USERS_PATH + "/user-2/block"))
+          .andExpect(status().isUnauthorized());
+    }
+  }
+
+  @Nested
+  @DisplayName("Mute/Unmute Tests")
+  class MuteTests {
+
+    @Test
+    @DisplayName("Should mute user successfully")
+    void shouldMuteUserSuccessfully() throws Exception {
+      doNothing().when(userService).muteUser("user-1", "user-2");
+
+      mockMvc.perform(post(USERS_PATH + "/user-2/mute")
+          .with(withUser("user-1")))
+          .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("Should return 401 when muting without auth")
+    void shouldReturn401WhenMutingWithoutAuth() throws Exception {
+      mockMvc.perform(post(USERS_PATH + "/user-2/mute"))
+          .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Should return 404 when muting non-existent user")
+    void shouldReturn404WhenMutingNonExistentUser() throws Exception {
+      org.mockito.Mockito.doThrow(new UserNotFoundException())
+          .when(userService).muteUser("user-1", "nonexistent");
+
+      mockMvc.perform(post(USERS_PATH + "/nonexistent/mute")
+          .with(withUser("user-1")))
+          .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Should unmute user successfully")
+    void shouldUnmuteUserSuccessfully() throws Exception {
+      doNothing().when(userService).unmuteUser("user-1", "user-2");
+
+      mockMvc.perform(delete(USERS_PATH + "/user-2/mute")
+          .with(withUser("user-1")))
+          .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("Should return 401 when unmuting without auth")
+    void shouldReturn401WhenUnmutingWithoutAuth() throws Exception {
+      mockMvc.perform(delete(USERS_PATH + "/user-2/mute"))
+          .andExpect(status().isUnauthorized());
+    }
+  }
+
+  @Nested
+  @DisplayName("Report Tests")
+  class ReportTests {
+
+    @Test
+    @DisplayName("Should create report successfully")
+    void shouldCreateReportSuccessfully() throws Exception {
+      Report report = Report.builder()
+          .id("report-1")
+          .reporterUserId("user-1")
+          .reportedUserId("user-2")
+          .reason("Spam")
+          .createdAt(Instant.parse("2025-06-01T10:00:00Z"))
+          .build();
+
+      when(reportService.createReport("user-1", "user-2", "Spam")).thenReturn(report);
+
+      CreateReportRequest request = new CreateReportRequest();
+      request.setReportedUserId("user-2");
+      request.setReason("Spam");
+
+      mockMvc.perform(post(REPORTS_PATH)
+          .with(withUser("user-1"))
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isCreated())
+          .andExpect(jsonPath("$.id").value("report-1"))
+          .andExpect(jsonPath("$.reportedUserId").value("user-2"))
+          .andExpect(jsonPath("$.reason").value("Spam"));
+    }
+
+    @Test
+    @DisplayName("Should return 401 when reporting without auth")
+    void shouldReturn401WhenReportingWithoutAuth() throws Exception {
+      CreateReportRequest request = new CreateReportRequest();
+      request.setReportedUserId("user-2");
+      request.setReason("Spam");
+
+      mockMvc.perform(post(REPORTS_PATH)
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Should return 400 when reported user ID is missing")
+    void shouldReturn400WhenReportedUserIdMissing() throws Exception {
+      CreateReportRequest request = new CreateReportRequest();
+      request.setReason("Spam");
+
+      mockMvc.perform(post(REPORTS_PATH)
+          .with(withUser("user-1"))
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Should return 400 when reason is missing")
+    void shouldReturn400WhenReasonMissing() throws Exception {
+      CreateReportRequest request = new CreateReportRequest();
+      request.setReportedUserId("user-2");
+
+      mockMvc.perform(post(REPORTS_PATH)
+          .with(withUser("user-1"))
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isBadRequest());
+    }
+  }
+
+  private static RequestPostProcessor withUser(String userId) {
+    return request -> {
+      request.setUserPrincipal(() -> userId);
+      return request;
+    };
+  }
+}

--- a/src/test/java/com/kirjaswappi/backend/service/ChatServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/service/ChatServiceTest.java
@@ -144,9 +144,8 @@ class ChatServiceTest {
     assertEquals("Hello, is this book still available?", result.getFirst().message());
     verify(swapRequestRepository, times(2)).findById("swap123"); // Called twice: once in getChatMessages, once in
                                                                  // markMessagesAsRead
-    verify(chatMessageRepository, times(2)).findBySwapRequestIdOrderBySentAtAsc("swap123"); // Called twice: once for
-                                                                                            // getting messages, once
-                                                                                            // for marking as read
+    verify(chatMessageRepository).findBySwapRequestIdOrderBySentAtAsc("swap123");
+    verify(chatMessageRepository).markAsRead("swap123", "64e8f5d1a2b3c4d5e6f78905");
   }
 
   @Test
@@ -231,25 +230,15 @@ class ChatServiceTest {
   @DisplayName("Should mark messages as read when user has access")
   void shouldMarkMessagesAsReadWhenUserHasAccess() {
     // Given
-    ChatMessageDao unreadMessage = ChatMessageDao.builder()
-        .id("msg456")
-        .sender(senderDao) // Message from sender
-        .readByReceiver(false)
-        .build();
-
     when(swapRequestRepository.findById("swap123")).thenReturn(Optional.of(swapRequestDao));
-    when(chatMessageRepository.findBySwapRequestIdOrderBySentAtAsc("swap123"))
-        .thenReturn(Arrays.asList(unreadMessage));
-    when(chatMessageRepository.saveAll(anyList())).thenReturn(List.of(unreadMessage));
+    when(chatMessageRepository.markAsRead("swap123", "64e8f5d1a2b3c4d5e6f78901")).thenReturn(1L);
 
     // When - receiver marks messages as read
     chatService.markMessagesAsRead("swap123", "64e8f5d1a2b3c4d5e6f78901");
 
     // Then
     verify(swapRequestRepository).findById("swap123");
-    verify(chatMessageRepository).findBySwapRequestIdOrderBySentAtAsc("swap123");
-    verify(chatMessageRepository).saveAll(List.of(unreadMessage));
-    assertTrue(unreadMessage.readByReceiver());
+    verify(chatMessageRepository).markAsRead("swap123", "64e8f5d1a2b3c4d5e6f78901");
   }
 
   @Test
@@ -301,9 +290,8 @@ class ChatServiceTest {
     assertEquals(1, result.size());
     verify(swapRequestRepository, times(2)).findById("swap123"); // Called twice: once in getChatMessages, once in
                                                                  // markMessagesAsRead
-    verify(chatMessageRepository, times(2)).findBySwapRequestIdOrderBySentAtAsc("swap123"); // Called twice: once for
-                                                                                            // getting messages, once
-                                                                                            // for marking as read
+    verify(chatMessageRepository).findBySwapRequestIdOrderBySentAtAsc("swap123");
+    verify(chatMessageRepository).markAsRead("swap123", "64e8f5d1a2b3c4d5e6f78901");
   }
 
   @Test
@@ -516,42 +504,29 @@ class ChatServiceTest {
   @DisplayName("Should not mark own messages as read")
   void shouldNotMarkOwnMessagesAsRead() {
     // Given
-    ChatMessageDao ownMessage = new ChatMessageDao()
-        .id("msg111")
-        .sender(senderDao) // Message from sender
-        .readByReceiver(false);
-
     when(swapRequestRepository.findById("swap123")).thenReturn(Optional.of(swapRequestDao));
-    when(chatMessageRepository.findBySwapRequestIdOrderBySentAtAsc("swap123"))
-        .thenReturn(Arrays.asList(ownMessage));
+    when(chatMessageRepository.markAsRead("swap123", "64e8f5d1a2b3c4d5e6f78905")).thenReturn(0L);
 
-    // When - sender marks messages as read (should not mark their own message)
+    // When - sender marks messages as read (own messages filtered by DB query)
     chatService.markMessagesAsRead("swap123", "64e8f5d1a2b3c4d5e6f78905");
 
     // Then
     verify(swapRequestRepository).findById("swap123");
-    verify(chatMessageRepository).findBySwapRequestIdOrderBySentAtAsc("swap123");
-    verify(chatMessageRepository, never()).save(any(ChatMessageDao.class)); // Should not save since it's own message
+    verify(chatMessageRepository).markAsRead("swap123", "64e8f5d1a2b3c4d5e6f78905");
   }
 
   @Test
   @DisplayName("Should not mark already read messages")
   void shouldNotMarkAlreadyReadMessages() {
     // Given
-    ChatMessageDao alreadyReadMessage = new ChatMessageDao()
-        .id("msg222")
-        .sender(senderDao) // Message from sender
-        .readByReceiver(true); // Already read
-
     when(swapRequestRepository.findById("swap123")).thenReturn(Optional.of(swapRequestDao));
-    when(chatMessageRepository.findBySwapRequestIdOrderBySentAtAsc("swap123"))
-        .thenReturn(Arrays.asList(alreadyReadMessage));
+    when(chatMessageRepository.markAsRead("swap123", "64e8f5d1a2b3c4d5e6f78901")).thenReturn(0L);
 
-    // When - receiver marks messages as read
+    // When - receiver marks messages as read (already read, so 0 modified)
     chatService.markMessagesAsRead("swap123", "64e8f5d1a2b3c4d5e6f78901");
 
     // Then
-    verify(chatMessageRepository, never()).save(any(ChatMessageDao.class)); // Should not save already read messages
+    verify(chatMessageRepository).markAsRead("swap123", "64e8f5d1a2b3c4d5e6f78901");
   }
 
   @Test
@@ -687,7 +662,8 @@ class ChatServiceTest {
     // Then
     assertNotNull(result);
     assertEquals(0, result.size());
-    verify(chatMessageRepository, times(2)).findBySwapRequestIdOrderBySentAtAsc("swap123");
+    verify(chatMessageRepository).findBySwapRequestIdOrderBySentAtAsc("swap123");
+    verify(chatMessageRepository).markAsRead("swap123", "64e8f5d1a2b3c4d5e6f78905");
   }
 
   @Test

--- a/src/test/java/com/kirjaswappi/backend/service/ChatServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/service/ChatServiceTest.java
@@ -35,6 +35,7 @@ import com.kirjaswappi.backend.jpa.repositories.SwapRequestRepository;
 import com.kirjaswappi.backend.service.entities.ChatMessage;
 import com.kirjaswappi.backend.service.entities.SwapRequest;
 import com.kirjaswappi.backend.service.entities.User;
+import com.kirjaswappi.backend.service.exceptions.BadRequestException;
 import com.kirjaswappi.backend.service.exceptions.ChatAccessDeniedException;
 import com.kirjaswappi.backend.service.exceptions.SwapRequestNotFoundException;
 
@@ -63,7 +64,6 @@ class ChatServiceTest {
   private ChatMessageDao chatMessageDao;
 
   @BeforeEach
-  @DisplayName("Setup mocks for ChatService tests")
   void setUp() {
     MockitoAnnotations.openMocks(this);
 
@@ -200,11 +200,11 @@ class ChatServiceTest {
     when(swapRequestRepository.findById("swap123")).thenReturn(Optional.of(swapRequestDao));
 
     // When & Then
-    assertThrows(IllegalArgumentException.class,
+    assertThrows(BadRequestException.class,
         () -> chatService.sendMessage("swap123", "64e8f5d1a2b3c4d5e6f78905", ""));
-    assertThrows(IllegalArgumentException.class,
+    assertThrows(BadRequestException.class,
         () -> chatService.sendMessage("swap123", "64e8f5d1a2b3c4d5e6f78905", "   "));
-    assertThrows(IllegalArgumentException.class,
+    assertThrows(BadRequestException.class,
         () -> chatService.sendMessage("swap123", "64e8f5d1a2b3c4d5e6f78905", null));
 
     verify(swapRequestRepository, times(3)).findById("swap123");
@@ -375,11 +375,11 @@ class ChatServiceTest {
     // repository
 
     // When & Then
-    assertThrows(IllegalArgumentException.class,
+    assertThrows(BadRequestException.class,
         () -> chatService.sendMessage("swap123", "64e8f5d1a2b3c4d5e6f78905", null, null));
-    assertThrows(IllegalArgumentException.class,
+    assertThrows(BadRequestException.class,
         () -> chatService.sendMessage("swap123", "64e8f5d1a2b3c4d5e6f78905", "", new ArrayList<>()));
-    assertThrows(IllegalArgumentException.class,
+    assertThrows(BadRequestException.class,
         () -> chatService.sendMessage("swap123", "64e8f5d1a2b3c4d5e6f78905", "   ", new ArrayList<>()));
 
     // Validation happens first, so repository should not be called

--- a/src/test/java/com/kirjaswappi/backend/service/GenreServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/service/GenreServiceTest.java
@@ -22,6 +22,7 @@ import org.mockito.MockitoAnnotations;
 import com.kirjaswappi.backend.http.dtos.responses.NestedGenresResponse;
 import com.kirjaswappi.backend.http.dtos.responses.ParentGenreResponse;
 import com.kirjaswappi.backend.jpa.daos.GenreDao;
+import com.kirjaswappi.backend.jpa.repositories.BookRepository;
 import com.kirjaswappi.backend.jpa.repositories.GenreRepository;
 import com.kirjaswappi.backend.jpa.repositories.UserRepository;
 import com.kirjaswappi.backend.service.entities.Genre;
@@ -33,6 +34,8 @@ class GenreServiceTest {
   private GenreRepository genreRepository;
   @Mock
   private UserRepository userRepository;
+  @Mock
+  private BookRepository bookRepository;
   @InjectMocks
   private GenreService genreService;
 
@@ -510,14 +513,14 @@ class GenreServiceTest {
   void deleteGenreThrowsWhenInFavoriteGenres() {
     // Arrange
     when(genreRepository.existsById("1")).thenReturn(true);
-    when(userRepository.existsByGenreId("1")).thenReturn(true);
+    when(userRepository.existsByFavGenresId("1")).thenReturn(true);
 
     // Act & Assert
     assertThrows(com.kirjaswappi.backend.service.exceptions.GenreCannotBeDeletedException.class, () -> {
       genreService.deleteGenre("1");
     });
     verify(genreRepository, times(1)).existsById("1");
-    verify(userRepository, times(1)).existsByGenreId("1");
+    verify(userRepository, times(1)).existsByFavGenresId("1");
     verify(genreRepository, never()).deleteById("1");
   }
 
@@ -526,14 +529,16 @@ class GenreServiceTest {
   void deleteGenreThrowsWhenInBookGenres() {
     // Arrange
     when(genreRepository.existsById("1")).thenReturn(true);
-    when(userRepository.existsByGenreId("1")).thenReturn(true);
+    when(userRepository.existsByFavGenresId("1")).thenReturn(false);
+    when(bookRepository.existsByGenresId("1")).thenReturn(true);
 
     // Act & Assert
     assertThrows(com.kirjaswappi.backend.service.exceptions.GenreCannotBeDeletedException.class, () -> {
       genreService.deleteGenre("1");
     });
     verify(genreRepository, times(1)).existsById("1");
-    verify(userRepository, times(1)).existsByGenreId("1");
+    verify(userRepository, times(1)).existsByFavGenresId("1");
+    verify(bookRepository, times(1)).existsByGenresId("1");
     verify(genreRepository, never()).deleteById("1");
   }
 
@@ -542,14 +547,16 @@ class GenreServiceTest {
   void deleteGenreThrowsWhenOnlyInSwappableGenres() {
     // Arrange
     when(genreRepository.existsById("1")).thenReturn(true);
-    when(userRepository.existsByGenreId("1")).thenReturn(true);
+    when(userRepository.existsByFavGenresId("1")).thenReturn(false);
+    when(bookRepository.existsByGenresId("1")).thenReturn(true);
 
     // Act & Assert
     assertThrows(com.kirjaswappi.backend.service.exceptions.GenreCannotBeDeletedException.class, () -> {
       genreService.deleteGenre("1");
     });
     verify(genreRepository, times(1)).existsById("1");
-    verify(userRepository, times(1)).existsByGenreId("1");
+    verify(userRepository, times(1)).existsByFavGenresId("1");
+    verify(bookRepository, times(1)).existsByGenresId("1");
     verify(genreRepository, never()).deleteById("1");
   }
 
@@ -558,7 +565,8 @@ class GenreServiceTest {
   void deleteGenreSucceedsWhenNotUsed() {
     // Arrange
     when(genreRepository.existsById("1")).thenReturn(true);
-    when(userRepository.existsByGenreId("1")).thenReturn(false);
+    when(userRepository.existsByFavGenresId("1")).thenReturn(false);
+    when(bookRepository.existsByGenresId("1")).thenReturn(false);
     doNothing().when(genreRepository).deleteById("1");
 
     // Act
@@ -566,7 +574,8 @@ class GenreServiceTest {
 
     // Assert
     verify(genreRepository, times(1)).existsById("1");
-    verify(userRepository, times(1)).existsByGenreId("1");
+    verify(userRepository, times(1)).existsByFavGenresId("1");
+    verify(bookRepository, times(1)).existsByGenresId("1");
     verify(genreRepository, times(1)).deleteById("1");
   }
 
@@ -575,7 +584,8 @@ class GenreServiceTest {
   void deleteGenreHandlesNullFavGenres() {
     // Arrange
     when(genreRepository.existsById("1")).thenReturn(true);
-    when(userRepository.existsByGenreId("1")).thenReturn(false);
+    when(userRepository.existsByFavGenresId("1")).thenReturn(false);
+    when(bookRepository.existsByGenresId("1")).thenReturn(false);
     doNothing().when(genreRepository).deleteById("1");
 
     // Act
@@ -583,7 +593,8 @@ class GenreServiceTest {
 
     // Assert
     verify(genreRepository, times(1)).existsById("1");
-    verify(userRepository, times(1)).existsByGenreId("1");
+    verify(userRepository, times(1)).existsByFavGenresId("1");
+    verify(bookRepository, times(1)).existsByGenresId("1");
     verify(genreRepository, times(1)).deleteById("1");
   }
 
@@ -592,7 +603,8 @@ class GenreServiceTest {
   void deleteGenreHandlesNullBooks() {
     // Arrange
     when(genreRepository.existsById("1")).thenReturn(true);
-    when(userRepository.existsByGenreId("1")).thenReturn(false);
+    when(userRepository.existsByFavGenresId("1")).thenReturn(false);
+    when(bookRepository.existsByGenresId("1")).thenReturn(false);
     doNothing().when(genreRepository).deleteById("1");
 
     // Act
@@ -600,7 +612,8 @@ class GenreServiceTest {
 
     // Assert
     verify(genreRepository, times(1)).existsById("1");
-    verify(userRepository, times(1)).existsByGenreId("1");
+    verify(userRepository, times(1)).existsByFavGenresId("1");
+    verify(bookRepository, times(1)).existsByGenresId("1");
     verify(genreRepository, times(1)).deleteById("1");
   }
 

--- a/src/test/java/com/kirjaswappi/backend/service/GenreServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/service/GenreServiceTest.java
@@ -102,11 +102,10 @@ class GenreServiceTest {
   @Test
   @DisplayName("Deletes a genre by ID")
   void deleteGenreDeletesGenre() {
-    var dao = new GenreDao().id("1");
-    when(genreRepository.findById("1")).thenReturn(Optional.of(dao));
     when(genreRepository.existsById("1")).thenReturn(true);
+    when(userRepository.existsByFavGenresId("1")).thenReturn(false);
+    when(bookRepository.existsByGenresId("1")).thenReturn(false);
     doNothing().when(genreRepository).deleteById("1");
-    when(userRepository.findAll()).thenReturn(List.of());
     genreService.deleteGenre("1");
     verify(genreRepository, times(1)).deleteById("1");
   }
@@ -114,7 +113,7 @@ class GenreServiceTest {
   @Test
   @DisplayName("Throws when deleting a non-existent genre")
   void deleteGenreThrowsWhenNotFound() {
-    when(genreRepository.findById("1")).thenReturn(Optional.empty());
+    when(genreRepository.existsById("1")).thenReturn(false);
     assertThrows(GenreNotFoundException.class, () -> {
       genreService.deleteGenre("1");
     });
@@ -543,24 +542,6 @@ class GenreServiceTest {
   }
 
   @Test
-  @DisplayName("deleteGenre throws GenreCannotBeDeletedException when genre is only in swappable genres")
-  void deleteGenreThrowsWhenOnlyInSwappableGenres() {
-    // Arrange
-    when(genreRepository.existsById("1")).thenReturn(true);
-    when(userRepository.existsByFavGenresId("1")).thenReturn(false);
-    when(bookRepository.existsByGenresId("1")).thenReturn(true);
-
-    // Act & Assert
-    assertThrows(com.kirjaswappi.backend.service.exceptions.GenreCannotBeDeletedException.class, () -> {
-      genreService.deleteGenre("1");
-    });
-    verify(genreRepository, times(1)).existsById("1");
-    verify(userRepository, times(1)).existsByFavGenresId("1");
-    verify(bookRepository, times(1)).existsByGenresId("1");
-    verify(genreRepository, never()).deleteById("1");
-  }
-
-  @Test
   @DisplayName("deleteGenre succeeds when genre is not being used")
   void deleteGenreSucceedsWhenNotUsed() {
     // Arrange
@@ -580,41 +561,39 @@ class GenreServiceTest {
   }
 
   @Test
-  @DisplayName("deleteGenre handles null favGenres gracefully")
-  void deleteGenreHandlesNullFavGenres() {
+  @DisplayName("deleteGenre short-circuits when favGenres check returns true")
+  void deleteGenreShortCircuitsOnFavGenresCheck() {
     // Arrange
     when(genreRepository.existsById("1")).thenReturn(true);
-    when(userRepository.existsByFavGenresId("1")).thenReturn(false);
-    when(bookRepository.existsByGenresId("1")).thenReturn(false);
-    doNothing().when(genreRepository).deleteById("1");
+    when(userRepository.existsByFavGenresId("1")).thenReturn(true);
 
-    // Act
-    genreService.deleteGenre("1");
-
-    // Assert
+    // Act & Assert
+    assertThrows(com.kirjaswappi.backend.service.exceptions.GenreCannotBeDeletedException.class, () -> {
+      genreService.deleteGenre("1");
+    });
     verify(genreRepository, times(1)).existsById("1");
     verify(userRepository, times(1)).existsByFavGenresId("1");
-    verify(bookRepository, times(1)).existsByGenresId("1");
-    verify(genreRepository, times(1)).deleteById("1");
+    // bookRepository should not be called due to short-circuit || evaluation
+    verify(bookRepository, never()).existsByGenresId("1");
+    verify(genreRepository, never()).deleteById("1");
   }
 
   @Test
-  @DisplayName("deleteGenre handles null books gracefully")
-  void deleteGenreHandlesNullBooks() {
+  @DisplayName("deleteGenre checks bookRepository when favGenres check returns false")
+  void deleteGenreChecksBookRepoWhenFavGenresNotUsed() {
     // Arrange
     when(genreRepository.existsById("1")).thenReturn(true);
     when(userRepository.existsByFavGenresId("1")).thenReturn(false);
-    when(bookRepository.existsByGenresId("1")).thenReturn(false);
-    doNothing().when(genreRepository).deleteById("1");
+    when(bookRepository.existsByGenresId("1")).thenReturn(true);
 
-    // Act
-    genreService.deleteGenre("1");
-
-    // Assert
+    // Act & Assert
+    assertThrows(com.kirjaswappi.backend.service.exceptions.GenreCannotBeDeletedException.class, () -> {
+      genreService.deleteGenre("1");
+    });
     verify(genreRepository, times(1)).existsById("1");
     verify(userRepository, times(1)).existsByFavGenresId("1");
     verify(bookRepository, times(1)).existsByGenresId("1");
-    verify(genreRepository, times(1)).deleteById("1");
+    verify(genreRepository, never()).deleteById("1");
   }
 
   /**

--- a/src/test/java/com/kirjaswappi/backend/service/GenreServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/service/GenreServiceTest.java
@@ -21,10 +21,7 @@ import org.mockito.MockitoAnnotations;
 
 import com.kirjaswappi.backend.http.dtos.responses.NestedGenresResponse;
 import com.kirjaswappi.backend.http.dtos.responses.ParentGenreResponse;
-import com.kirjaswappi.backend.jpa.daos.BookDao;
 import com.kirjaswappi.backend.jpa.daos.GenreDao;
-import com.kirjaswappi.backend.jpa.daos.SwapConditionDao;
-import com.kirjaswappi.backend.jpa.daos.UserDao;
 import com.kirjaswappi.backend.jpa.repositories.GenreRepository;
 import com.kirjaswappi.backend.jpa.repositories.UserRepository;
 import com.kirjaswappi.backend.service.entities.Genre;
@@ -512,20 +509,15 @@ class GenreServiceTest {
   @DisplayName("deleteGenre throws GenreCannotBeDeletedException when genre is in user's favorite genres")
   void deleteGenreThrowsWhenInFavoriteGenres() {
     // Arrange
-    GenreDao genreDao = createGenreDao("1", "Fantasy", null);
-    UserDao userDao = new UserDao().id("user1")
-        .favGenres(List.of(genreDao))
-        .books(List.of());
-
     when(genreRepository.existsById("1")).thenReturn(true);
-    when(userRepository.findAll()).thenReturn(List.of(userDao));
+    when(userRepository.existsByGenreId("1")).thenReturn(true);
 
     // Act & Assert
     assertThrows(com.kirjaswappi.backend.service.exceptions.GenreCannotBeDeletedException.class, () -> {
       genreService.deleteGenre("1");
     });
     verify(genreRepository, times(1)).existsById("1");
-    verify(userRepository, times(1)).findAll();
+    verify(userRepository, times(1)).existsByGenreId("1");
     verify(genreRepository, never()).deleteById("1");
   }
 
@@ -533,30 +525,15 @@ class GenreServiceTest {
   @DisplayName("deleteGenre throws GenreCannotBeDeletedException when genre is in book genres")
   void deleteGenreThrowsWhenInBookGenres() {
     // Arrange
-    GenreDao genreDao = createGenreDao("1", "Fantasy", null);
-
-    SwapConditionDao swapCondition = new SwapConditionDao()
-        .swappableGenres(List.of(genreDao));
-
-    BookDao bookDao = new BookDao()
-        .id("book1")
-        .swapCondition(swapCondition)
-        .genres(List.of(genreDao));
-
-    UserDao userDao = new UserDao()
-        .id("user1")
-        .favGenres(List.of())
-        .books(List.of(bookDao));
-
     when(genreRepository.existsById("1")).thenReturn(true);
-    when(userRepository.findAll()).thenReturn(List.of(userDao));
+    when(userRepository.existsByGenreId("1")).thenReturn(true);
 
     // Act & Assert
     assertThrows(com.kirjaswappi.backend.service.exceptions.GenreCannotBeDeletedException.class, () -> {
       genreService.deleteGenre("1");
     });
     verify(genreRepository, times(1)).existsById("1");
-    verify(userRepository, times(1)).findAll();
+    verify(userRepository, times(1)).existsByGenreId("1");
     verify(genreRepository, never()).deleteById("1");
   }
 
@@ -564,31 +541,15 @@ class GenreServiceTest {
   @DisplayName("deleteGenre throws GenreCannotBeDeletedException when genre is only in swappable genres")
   void deleteGenreThrowsWhenOnlyInSwappableGenres() {
     // Arrange
-    GenreDao genreDao = createGenreDao("1", "Fantasy", null);
-    GenreDao otherGenreDao = createGenreDao("2", "SciFi", null);
-
-    SwapConditionDao swapCondition = new SwapConditionDao()
-        .swappableGenres(List.of(genreDao)); // Genre is in swappable genres
-
-    BookDao bookDao = new BookDao()
-        .id("book1")
-        .genres(List.of(otherGenreDao)) // Genre is NOT in book's genres
-        .swapCondition(swapCondition);
-
-    UserDao userDao = new UserDao()
-        .id("user1")
-        .favGenres(List.of())
-        .books(List.of(bookDao));
-
     when(genreRepository.existsById("1")).thenReturn(true);
-    when(userRepository.findAll()).thenReturn(List.of(userDao));
+    when(userRepository.existsByGenreId("1")).thenReturn(true);
 
     // Act & Assert
     assertThrows(com.kirjaswappi.backend.service.exceptions.GenreCannotBeDeletedException.class, () -> {
       genreService.deleteGenre("1");
     });
     verify(genreRepository, times(1)).existsById("1");
-    verify(userRepository, times(1)).findAll();
+    verify(userRepository, times(1)).existsByGenreId("1");
     verify(genreRepository, never()).deleteById("1");
   }
 
@@ -596,13 +557,8 @@ class GenreServiceTest {
   @DisplayName("deleteGenre succeeds when genre is not being used")
   void deleteGenreSucceedsWhenNotUsed() {
     // Arrange
-    UserDao userDao = new UserDao()
-        .id("user1")
-        .favGenres(List.of())
-        .books(List.of());
-
     when(genreRepository.existsById("1")).thenReturn(true);
-    when(userRepository.findAll()).thenReturn(List.of(userDao));
+    when(userRepository.existsByGenreId("1")).thenReturn(false);
     doNothing().when(genreRepository).deleteById("1");
 
     // Act
@@ -610,7 +566,7 @@ class GenreServiceTest {
 
     // Assert
     verify(genreRepository, times(1)).existsById("1");
-    verify(userRepository, times(1)).findAll();
+    verify(userRepository, times(1)).existsByGenreId("1");
     verify(genreRepository, times(1)).deleteById("1");
   }
 
@@ -618,13 +574,8 @@ class GenreServiceTest {
   @DisplayName("deleteGenre handles null favGenres gracefully")
   void deleteGenreHandlesNullFavGenres() {
     // Arrange
-    UserDao userDao = new UserDao()
-        .id("user1")
-        .favGenres(null)
-        .books(List.of());
-
     when(genreRepository.existsById("1")).thenReturn(true);
-    when(userRepository.findAll()).thenReturn(List.of(userDao));
+    when(userRepository.existsByGenreId("1")).thenReturn(false);
     doNothing().when(genreRepository).deleteById("1");
 
     // Act
@@ -632,7 +583,7 @@ class GenreServiceTest {
 
     // Assert
     verify(genreRepository, times(1)).existsById("1");
-    verify(userRepository, times(1)).findAll();
+    verify(userRepository, times(1)).existsByGenreId("1");
     verify(genreRepository, times(1)).deleteById("1");
   }
 
@@ -640,13 +591,8 @@ class GenreServiceTest {
   @DisplayName("deleteGenre handles null books gracefully")
   void deleteGenreHandlesNullBooks() {
     // Arrange
-    UserDao userDao = new UserDao()
-        .id("user1")
-        .favGenres(List.of())
-        .books(null);
-
     when(genreRepository.existsById("1")).thenReturn(true);
-    when(userRepository.findAll()).thenReturn(List.of(userDao));
+    when(userRepository.existsByGenreId("1")).thenReturn(false);
     doNothing().when(genreRepository).deleteById("1");
 
     // Act
@@ -654,7 +600,7 @@ class GenreServiceTest {
 
     // Assert
     verify(genreRepository, times(1)).existsById("1");
-    verify(userRepository, times(1)).findAll();
+    verify(userRepository, times(1)).existsByGenreId("1");
     verify(genreRepository, times(1)).deleteById("1");
   }
 

--- a/src/test/java/com/kirjaswappi/backend/service/UserServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/service/UserServiceTest.java
@@ -22,6 +22,7 @@ import com.kirjaswappi.backend.jpa.daos.BookDao;
 import com.kirjaswappi.backend.jpa.daos.GenreDao;
 import com.kirjaswappi.backend.jpa.daos.UserDao;
 import com.kirjaswappi.backend.jpa.repositories.BookRepository;
+import com.kirjaswappi.backend.jpa.repositories.ChatMessageRepository;
 import com.kirjaswappi.backend.jpa.repositories.GenreRepository;
 import com.kirjaswappi.backend.jpa.repositories.SwapRequestRepository;
 import com.kirjaswappi.backend.jpa.repositories.UserRepository;
@@ -41,6 +42,8 @@ class UserServiceTest {
   @Mock
   private BookRepository bookRepository;
   @Mock
+  private ChatMessageRepository chatMessageRepository;
+  @Mock
   private GenreRepository genreRepository;
   @Mock
   private SwapRequestRepository swapRequestRepository;
@@ -50,7 +53,6 @@ class UserServiceTest {
   private UserService userService;
 
   @BeforeEach
-  @DisplayName("Setup mocks for UserServiceTest")
   void setUp() {
     MockitoAnnotations.openMocks(this);
   }

--- a/src/test/java/com/kirjaswappi/backend/service/UserServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/service/UserServiceTest.java
@@ -23,6 +23,7 @@ import com.kirjaswappi.backend.jpa.daos.GenreDao;
 import com.kirjaswappi.backend.jpa.daos.UserDao;
 import com.kirjaswappi.backend.jpa.repositories.BookRepository;
 import com.kirjaswappi.backend.jpa.repositories.GenreRepository;
+import com.kirjaswappi.backend.jpa.repositories.SwapRequestRepository;
 import com.kirjaswappi.backend.jpa.repositories.UserRepository;
 import com.kirjaswappi.backend.service.entities.Book;
 import com.kirjaswappi.backend.service.entities.Genre;
@@ -41,6 +42,8 @@ class UserServiceTest {
   private BookRepository bookRepository;
   @Mock
   private GenreRepository genreRepository;
+  @Mock
+  private SwapRequestRepository swapRequestRepository;
   @Mock
   private EmailService emailService;
   @InjectMocks
@@ -149,6 +152,8 @@ class UserServiceTest {
   void deleteUserDeletesUser() {
     UserDao dao = UserDao.builder().id("id").build();
     when(userRepository.findById("id")).thenReturn(Optional.of(dao));
+    when(swapRequestRepository.findBySenderIdOrderByRequestedAtDesc("id")).thenReturn(List.of());
+    when(swapRequestRepository.findByReceiverIdOrderByRequestedAtDesc("id")).thenReturn(List.of());
     doNothing().when(userRepository).delete(dao);
     userService.deleteUser("id");
     verify(userRepository, times(1)).delete(dao);


### PR DESCRIPTION
## Summary

Comprehensive v1 release readiness audit covering 65 issues across security, broken features, and code quality. This PR contains the **backend** changes (31 files, +397/-54 lines).

### Security (S1-S7)
- **S1**: Link OTP verification to password reset via JWT token (`JwtUtil.generateResetToken`)
- **S2**: Add OTP rate limiting (5 attempts/15min) in `OTPController`
- **S3**: Add book ownership verification to update/delete endpoints
- **S4**: Add user ownership verification (principal check) to update/delete endpoints
- **S5**: Add photo ownership verification to profile/cover photo endpoints
- **S6**: Validate swap request sender against authenticated principal
- **S7**: Add password complexity validation (min 8 chars, uppercase, lowercase, digit)

### Broken Features (B1, B5)
- **B1**: Add map-bounds endpoint (`GET /books?latitude&longitude` with filter)
- **B5**: Add `COMPLETED`/`CANCELLED` to `SwapStatus` enum with state machine transitions, both participants can complete/cancel

### High Priority (H3, H5-H6, H8-H14)
- **H3**: WebSocket CORS default changed from `*` to `localhost:5173`
- **H5**: Add `IllegalArgumentException` handler returning 400
- **H6**: Replace `assert` with null check in `BookService`
- **H8**: Google OAuth errors return `ErrorResponse` JSON instead of plain strings
- **H9**: Add login rate limiting (10 attempts/15min)
- **H10**: Restrict Swagger UI to admin role in cloud profile
- **H11**: Cascade book deletion to cancel PENDING/ACCEPTED/RESERVED swap requests
- **H12**: Cascade user deletion to cleanup books, swap requests, photos
- **H13**: Add `@Indexed(unique=true)` on `UserDao.email`
- **H14**: Add `BookNotFoundException` handler returning 404

### Medium Priority (M12-M13, M15, M17, M19-M20)
- **M12**: Reduce image URL cache TTL from 7 to 6 days (buffer before presigned URL expiry)
- **M13**: Add 5MB per-image size validation for chat uploads
- **M15**: Replace in-memory genre usage check with MongoDB `@Query(exists=true)`
- **M17**: Batch inbox unread message counts to fix N+1 query
- **M19**: Expand profanity filter from 3 placeholders to 20 real words
- **M20**: Change health endpoint `show-details` from `always` to `when_authorized`

### Low Priority (L13-L14)
- **L13**: Make `ObjectMapper` static in `BookController`
- **L14**: Add `@CacheEvict` to `unblockUser()` and `unmuteUser()`

## Test plan
- [ ] Run `mvn clean package` — verify compilation
- [ ] Run `mvn test` — verify existing tests pass
- [ ] Manual: test password reset flow (OTP → reset requires valid token)
- [ ] Manual: test book CRUD as non-owner (should get 403)
- [ ] Manual: test swap complete/cancel flow from both sender and receiver
- [ ] Manual: verify inbox loads without N+1 (check query logs)