### PR TITLE
Add: DELETE endpoint for removing favourite books

### DIFF
--- a/src/main/java/com/kirjaswappi/backend/common/utils/Constants.java
+++ b/src/main/java/com/kirjaswappi/backend/common/utils/Constants.java
@@ -28,6 +28,7 @@ public class Constants {
   public static final String CHANGE_PASSWORD = "/change-password";
   public static final String RESET_PASSWORD = "/reset-password";
   public static final String ID = "/{id}";
+  public static final String BOOK_ID = "/{bookId}";
   public static final String MORE_BOOKS = "/more-books";
   public static final String USERNAME = "/{username}";
   public static final String EMAIL = "/{email}";

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/UserController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/UserController.java
@@ -109,6 +109,17 @@ public class UserController {
     return ResponseEntity.status(HttpStatus.OK).body(new UserResponse(updatedUser));
   }
 
+  @DeleteMapping(FAVOURITE_BOOKS + BOOK_ID)
+  @Operation(summary = "Remove a favourite book from a user.", responses = {
+      @ApiResponse(responseCode = "204", description = "Book removed from favourite list.") })
+  public ResponseEntity<Void> removeFavouriteBook(
+      @Parameter(description = "Book ID.") @PathVariable String bookId) {
+    var authentication = SecurityContextHolder.getContext().getAuthentication();
+    String userId = authentication.getName();
+    userService.removeFavouriteBook(userId, bookId);
+    return ResponseEntity.noContent().build();
+  }
+
   @PutMapping(ID)
   @Operation(summary = "Update user.", responses = {
       @ApiResponse(responseCode = "200", description = "User updated."),

--- a/src/main/java/com/kirjaswappi/backend/service/UserService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/UserService.java
@@ -308,6 +308,19 @@ public class UserService {
     return getUser(user.id());
   }
 
+  public void removeFavouriteBook(String userId, String bookId) {
+    var userDao = userRepository.findByIdAndIsEmailVerifiedTrue(userId)
+        .orElseThrow(() -> new UserNotFoundException(userId));
+
+    if (userDao.favBooks() == null || userDao.favBooks().stream()
+        .noneMatch(book -> book.id().equals(bookId))) {
+      throw new BadRequestException("bookNotFoundInFavBooks", bookId);
+    }
+
+    userDao.favBooks().removeIf(book -> book.id().equals(bookId));
+    userRepository.save(userDao);
+  }
+
   @CacheEvict(value = "users", key = "#userId")
   public void blockUser(String userId, String targetUserId) {
     var dao = userRepository.findByIdAndIsEmailVerifiedTrue(userId)


### PR DESCRIPTION
## Summary
- Adds `DELETE /api/v1/users/favourite-books/{bookId}` endpoint so users can unbookmark books
- Uses authenticated user principal (no request body needed)
- Returns 204 No Content on success, throws if book not in favourites
- Follows existing patterns (`deleteUser`, `unblockUser`)

## Test plan
- [ ] `DELETE /api/v1/users/favourite-books/{bookId}` removes the book from user's favBooks
- [ ] Returns 400 if book is not in favourites
- [ ] Returns 204 on success
- [ ] Requires user authentication (not platform token)