### PR TITLE
Fix: mark-as-read not persisting across reloads

### DIFF
--- a/src/main/java/com/kirjaswappi/backend/common/utils/Constants.java
+++ b/src/main/java/com/kirjaswappi/backend/common/utils/Constants.java
@@ -52,4 +52,5 @@ public class Constants {
   public static final String REPORTS = "/reports";
   public static final String BLOCK = "/block";
   public static final String MUTE = "/mute";
+  public static final String READ = "/read";
 }

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/ChatController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/ChatController.java
@@ -26,7 +26,6 @@ import org.springframework.web.bind.annotation.*;
 import com.kirjaswappi.backend.http.dtos.requests.SendMessageRequest;
 import com.kirjaswappi.backend.http.dtos.responses.ChatMessageResponse;
 import com.kirjaswappi.backend.service.ChatService;
-import com.kirjaswappi.backend.service.InboxService;
 import com.kirjaswappi.backend.service.entities.ChatMessage;
 import com.kirjaswappi.backend.service.entities.SwapRequest;
 
@@ -38,8 +37,6 @@ import com.kirjaswappi.backend.service.entities.SwapRequest;
 public class ChatController {
 
   private final ChatService chatService;
-
-  private final InboxService inboxService;
 
   @GetMapping(ID + CHAT)
   @Operation(summary = "Get chat messages for a swap request", description = "Retrieve all chat messages for a specific swap request with book swap context. User must be sender or receiver. Automatically marks messages as read.", responses = {
@@ -129,7 +126,6 @@ public class ChatController {
     String userId = principal.getName();
 
     chatService.markMessagesAsRead(id, userId);
-    inboxService.markInboxItemAsRead(id, userId);
 
     return ResponseEntity.noContent().build();
   }

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/ChatController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/ChatController.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.annotation.*;
 import com.kirjaswappi.backend.http.dtos.requests.SendMessageRequest;
 import com.kirjaswappi.backend.http.dtos.responses.ChatMessageResponse;
 import com.kirjaswappi.backend.service.ChatService;
+import com.kirjaswappi.backend.service.InboxService;
 import com.kirjaswappi.backend.service.entities.ChatMessage;
 import com.kirjaswappi.backend.service.entities.SwapRequest;
 
@@ -37,6 +38,8 @@ import com.kirjaswappi.backend.service.entities.SwapRequest;
 public class ChatController {
 
   private final ChatService chatService;
+
+  private final InboxService inboxService;
 
   @GetMapping(ID + CHAT)
   @Operation(summary = "Get chat messages for a swap request", description = "Retrieve all chat messages for a specific swap request with book swap context. User must be sender or receiver. Automatically marks messages as read.", responses = {
@@ -107,6 +110,28 @@ public class ChatController {
     response.setSwapContext(createSwapContext(swapRequest));
 
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  @PatchMapping(ID + CHAT + READ)
+  @Operation(summary = "Mark chat messages as read", description = "Mark all unread messages in a swap request chat as read for the authenticated user", responses = {
+      @ApiResponse(responseCode = "204", description = "Messages marked as read successfully"),
+      @ApiResponse(responseCode = "401", description = "Unauthorized - missing or invalid authentication"),
+      @ApiResponse(responseCode = "403", description = "Access denied - user not authorized for this chat"),
+      @ApiResponse(responseCode = "404", description = "Swap request not found")
+  })
+  public ResponseEntity<Void> markChatAsRead(
+      @Parameter(description = "Swap request ID", required = true) @PathVariable String id,
+      Principal principal) {
+
+    if (principal == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+    String userId = principal.getName();
+
+    chatService.markMessagesAsRead(id, userId);
+    inboxService.markInboxItemAsRead(id, userId);
+
+    return ResponseEntity.noContent().build();
   }
 
   private ChatMessageResponse.SwapContextResponse createSwapContext(SwapRequest swapRequest) {

--- a/src/main/java/com/kirjaswappi/backend/jpa/repositories/CustomChatMessageRepositoryImpl.java
+++ b/src/main/java/com/kirjaswappi/backend/jpa/repositories/CustomChatMessageRepositoryImpl.java
@@ -26,6 +26,6 @@ public class CustomChatMessageRepositoryImpl implements CustomChatMessageReposit
         .and("readByReceiver").is(false)
         .and("sender.$id").ne(new ObjectId(userId)));
     Update update = new Update().set("readByReceiver", true);
-    return mongoTemplate.updateMulti(query, update, "chatMessages").getModifiedCount();
+    return mongoTemplate.updateMulti(query, update, "chat_messages").getModifiedCount();
   }
 }

--- a/src/main/java/com/kirjaswappi/backend/jpa/repositories/CustomChatMessageRepositoryImpl.java
+++ b/src/main/java/com/kirjaswappi/backend/jpa/repositories/CustomChatMessageRepositoryImpl.java
@@ -11,6 +11,8 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Repository;
 
+import com.kirjaswappi.backend.jpa.daos.ChatMessageDao;
+
 @Repository
 public class CustomChatMessageRepositoryImpl implements CustomChatMessageRepository {
 
@@ -26,6 +28,6 @@ public class CustomChatMessageRepositoryImpl implements CustomChatMessageReposit
         .and("readByReceiver").is(false)
         .and("sender.$id").ne(new ObjectId(userId)));
     Update update = new Update().set("readByReceiver", true);
-    return mongoTemplate.updateMulti(query, update, "chat_messages").getModifiedCount();
+    return mongoTemplate.updateMulti(query, update, ChatMessageDao.class).getModifiedCount();
   }
 }

--- a/src/main/java/com/kirjaswappi/backend/service/ChatService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/ChatService.java
@@ -128,12 +128,7 @@ public class ChatService {
         : swapRequest.sender().id();
 
     // Reset the receiver's read timestamp so the inbox shows unread
-    if (swapRequest.receiver().id().equals(receiverId)) {
-      swapRequest.readByReceiverAt(null);
-    } else {
-      swapRequest.readBySenderAt(null);
-    }
-    swapRequestRepository.save(swapRequest);
+    resetRecipientReadTimestamp(swapRequest, receiverId);
 
     // Clear cache for both sender and receiver to avoid stale data
     clearUnreadCountCache(receiverId, swapRequestId);
@@ -205,12 +200,7 @@ public class ChatService {
         : swapRequest.sender().id();
 
     // Reset the receiver's read timestamp so the inbox shows unread
-    if (swapRequest.receiver().id().equals(receiverId)) {
-      swapRequest.readByReceiverAt(null);
-    } else {
-      swapRequest.readBySenderAt(null);
-    }
-    swapRequestRepository.save(swapRequest);
+    resetRecipientReadTimestamp(swapRequest, receiverId);
 
     // Clear cache for both sender and receiver to avoid stale data
     clearUnreadCountCache(receiverId, swapRequestId);
@@ -343,6 +333,15 @@ public class ChatService {
   private boolean hasAccessToChat(SwapRequestDao swapRequest, String userId) {
     return swapRequest.sender().id().equals(userId) ||
         swapRequest.receiver().id().equals(userId);
+  }
+
+  private void resetRecipientReadTimestamp(SwapRequestDao swapRequest, String recipientId) {
+    if (swapRequest.receiver().id().equals(recipientId)) {
+      swapRequest.readByReceiverAt(null);
+    } else {
+      swapRequest.readBySenderAt(null);
+    }
+    swapRequestRepository.save(swapRequest);
   }
 
   private List<String> convertImageIdsToUrls(List<String> imageIds) {

--- a/src/main/java/com/kirjaswappi/backend/service/ChatService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/ChatService.java
@@ -127,6 +127,14 @@ public class ChatService {
         ? swapRequest.receiver().id()
         : swapRequest.sender().id();
 
+    // Reset the receiver's read timestamp so the inbox shows unread
+    if (swapRequest.receiver().id().equals(receiverId)) {
+      swapRequest.readByReceiverAt(null);
+    } else {
+      swapRequest.readBySenderAt(null);
+    }
+    swapRequestRepository.save(swapRequest);
+
     // Clear cache for both sender and receiver to avoid stale data
     clearUnreadCountCache(receiverId, swapRequestId);
     clearUnreadCountCache(senderId, swapRequestId);
@@ -196,6 +204,14 @@ public class ChatService {
         ? swapRequest.receiver().id()
         : swapRequest.sender().id();
 
+    // Reset the receiver's read timestamp so the inbox shows unread
+    if (swapRequest.receiver().id().equals(receiverId)) {
+      swapRequest.readByReceiverAt(null);
+    } else {
+      swapRequest.readBySenderAt(null);
+    }
+    swapRequestRepository.save(swapRequest);
+
     // Clear cache for both sender and receiver to avoid stale data
     clearUnreadCountCache(receiverId, swapRequestId);
     clearUnreadCountCache(senderId, swapRequestId);
@@ -229,10 +245,10 @@ public class ChatService {
     // Also mark the swap request inbox item as read so the inbox endpoint returns
     // unread=false
     Instant now = Instant.now();
-    if (swapRequest.receiver().id().equals(userId) && swapRequest.readByReceiverAt() == null) {
+    if (swapRequest.receiver().id().equals(userId)) {
       swapRequest.readByReceiverAt(now);
       swapRequestRepository.save(swapRequest);
-    } else if (swapRequest.sender().id().equals(userId) && swapRequest.readBySenderAt() == null) {
+    } else if (swapRequest.sender().id().equals(userId)) {
       swapRequest.readBySenderAt(now);
       swapRequestRepository.save(swapRequest);
     }

--- a/src/main/java/com/kirjaswappi/backend/service/InboxService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/InboxService.java
@@ -154,19 +154,13 @@ public class InboxService {
 
     SwapRequestDao swapRequestDao = swapRequestOpt.get();
     Instant now = Instant.now();
-    boolean updated = false;
 
-    // Mark as read by the appropriate user
-    if (swapRequestDao.receiver().id().equals(userId) && swapRequestDao.readByReceiverAt() == null) {
+    // Always update the read timestamp
+    if (swapRequestDao.receiver().id().equals(userId)) {
       swapRequestDao.readByReceiverAt(now);
-      updated = true;
-    } else if (swapRequestDao.sender().id().equals(userId) && swapRequestDao.readBySenderAt() == null) {
+      swapRequestRepository.save(swapRequestDao);
+    } else if (swapRequestDao.sender().id().equals(userId)) {
       swapRequestDao.readBySenderAt(now);
-      updated = true;
-    }
-
-    // Save if updated
-    if (updated) {
       swapRequestRepository.save(swapRequestDao);
     }
   }

--- a/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/ChatControllerTest.java
+++ b/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/ChatControllerTest.java
@@ -27,7 +27,6 @@ import com.kirjaswappi.backend.common.http.controllers.mockMvc.config.CustomMock
 import com.kirjaswappi.backend.http.controllers.ChatController;
 import com.kirjaswappi.backend.http.dtos.requests.SendMessageRequest;
 import com.kirjaswappi.backend.service.ChatService;
-import com.kirjaswappi.backend.service.InboxService;
 import com.kirjaswappi.backend.service.entities.Book;
 import com.kirjaswappi.backend.service.entities.ChatMessage;
 import com.kirjaswappi.backend.service.entities.SwapRequest;
@@ -47,9 +46,6 @@ class ChatControllerTest {
 
   @MockitoBean
   private ChatService chatService;
-
-  @MockitoBean
-  private InboxService inboxService;
 
   @Autowired
   private ObjectMapper objectMapper;
@@ -335,6 +331,49 @@ class ChatControllerTest {
         .andExpect(status().isUnauthorized());
 
     verifyNoInteractions(chatService);
+  }
+
+  @Test
+  @DisplayName("Should return 204 when marking chat as read")
+  void shouldReturn204WhenMarkingChatAsRead() throws Exception {
+    mockMvc.perform(patch(API_PATH + "/swap123/chat/read")
+        .with(withUser("user123")))
+        .andExpect(status().isNoContent());
+
+    verify(chatService).markMessagesAsRead("swap123", "user123");
+  }
+
+  @Test
+  @DisplayName("Should return 401 when principal is missing for mark as read")
+  void shouldReturn401WhenPrincipalIsMissingForMarkAsRead() throws Exception {
+    mockMvc.perform(patch(API_PATH + "/swap123/chat/read"))
+        .andExpect(status().isUnauthorized());
+
+    verifyNoInteractions(chatService);
+  }
+
+  @Test
+  @DisplayName("Should return 404 when swap request not found for mark as read")
+  void shouldReturn404WhenSwapRequestNotFoundForMarkAsRead() throws Exception {
+    doThrow(new SwapRequestNotFoundException()).when(chatService).markMessagesAsRead("swap123", "user123");
+
+    mockMvc.perform(patch(API_PATH + "/swap123/chat/read")
+        .with(withUser("user123")))
+        .andExpect(status().isNotFound());
+
+    verify(chatService).markMessagesAsRead("swap123", "user123");
+  }
+
+  @Test
+  @DisplayName("Should return 403 when user has no access to mark as read")
+  void shouldReturn403WhenUserHasNoAccessToMarkAsRead() throws Exception {
+    doThrow(new ChatAccessDeniedException()).when(chatService).markMessagesAsRead("swap123", "user123");
+
+    mockMvc.perform(patch(API_PATH + "/swap123/chat/read")
+        .with(withUser("user123")))
+        .andExpect(status().isForbidden());
+
+    verify(chatService).markMessagesAsRead("swap123", "user123");
   }
 
   private static RequestPostProcessor withUser(String userId) {

--- a/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/ChatControllerTest.java
+++ b/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/ChatControllerTest.java
@@ -27,6 +27,7 @@ import com.kirjaswappi.backend.common.http.controllers.mockMvc.config.CustomMock
 import com.kirjaswappi.backend.http.controllers.ChatController;
 import com.kirjaswappi.backend.http.dtos.requests.SendMessageRequest;
 import com.kirjaswappi.backend.service.ChatService;
+import com.kirjaswappi.backend.service.InboxService;
 import com.kirjaswappi.backend.service.entities.Book;
 import com.kirjaswappi.backend.service.entities.ChatMessage;
 import com.kirjaswappi.backend.service.entities.SwapRequest;
@@ -46,6 +47,9 @@ class ChatControllerTest {
 
   @MockitoBean
   private ChatService chatService;
+
+  @MockitoBean
+  private InboxService inboxService;
 
   @Autowired
   private ObjectMapper objectMapper;

--- a/src/test/java/com/kirjaswappi/backend/service/InboxServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/service/InboxServiceTest.java
@@ -466,7 +466,7 @@ class InboxServiceTest {
   }
 
   @Test
-  @DisplayName("Should not update inbox item if already read by receiver")
+  @DisplayName("Should update inbox item even if already read by receiver")
   void shouldNotUpdateInboxItemIfAlreadyReadByReceiver() {
     // Given
     Instant readTime = Instant.parse("2025-01-01T12:00:00Z");
@@ -476,14 +476,15 @@ class InboxServiceTest {
     // When
     inboxService.markInboxItemAsRead("received1", "receiver123");
 
-    // Then
-    assertEquals(readTime, receivedSwapRequest.readByReceiverAt()); // Should remain unchanged
+    // Then - timestamp should be updated to a newer value
+    assertNotNull(receivedSwapRequest.readByReceiverAt());
+    assertNotEquals(readTime, receivedSwapRequest.readByReceiverAt());
     verify(swapRequestRepository).findById("received1");
-    verify(swapRequestRepository, never()).save(any()); // Should not save if already read
+    verify(swapRequestRepository).save(receivedSwapRequest);
   }
 
   @Test
-  @DisplayName("Should not update inbox item if already read by sender")
+  @DisplayName("Should update inbox item even if already read by sender")
   void shouldNotUpdateInboxItemIfAlreadyReadBySender() {
     // Given
     Instant readTime = Instant.parse("2025-01-01T12:00:00Z");
@@ -493,9 +494,10 @@ class InboxServiceTest {
     // When
     inboxService.markInboxItemAsRead("received1", "sender123");
 
-    // Then
-    assertEquals(readTime, receivedSwapRequest.readBySenderAt()); // Should remain unchanged
-    verify(swapRequestRepository, never()).save(any()); // Should not save if already read
+    // Then - timestamp should be updated to a newer value
+    assertNotNull(receivedSwapRequest.readBySenderAt());
+    assertNotEquals(readTime, receivedSwapRequest.readBySenderAt());
+    verify(swapRequestRepository).save(receivedSwapRequest);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Fix collection name mismatch in `CustomChatMessageRepositoryImpl.markAsRead` — was targeting `"chatMessages"` instead of `"chat_messages"`, so the bulk update silently did nothing and messages were never marked as read in MongoDB
- Remove `== null` guard on `readByReceiverAt`/`readBySenderAt` timestamps in `markMessagesAsRead` and `markInboxItemAsRead` — timestamps are now always updated so re-reading a chat works correctly
- Reset receiver's read timestamp to `null` in `sendMessage` when a new message is sent, so the inbox correctly shows unread status for new messages
- Add dedicated `PATCH /api/v1/swap-requests/{id}/chat/read` endpoint for explicit mark-as-read instead of relying on the GET /chat side effect

## Test plan
- [ ] Open a chat → badge clears, stays cleared after page reload
- [ ] Send a message from another user → inbox shows unread for receiver
- [ ] Open the unread chat → mark-as-read persists across reloads
- [ ] Verify `PATCH /swap-requests/{id}/chat/read` returns 204