### PR TITLE
Fix: make Swagger UI publicly accessible

### DIFF
--- a/src/main/java/com/kirjaswappi/backend/common/configs/CloudSecurityConfig.java
+++ b/src/main/java/com/kirjaswappi/backend/common/configs/CloudSecurityConfig.java
@@ -74,7 +74,7 @@ public class CloudSecurityConfig {
             .requestMatchers(DELETE, API_BASE + ADMIN_USERS + USERNAME).hasAuthority(ADMIN)
             .requestMatchers(DELETE, API_BASE + SWAP_REQUESTS).hasAuthority(ADMIN)
             .requestMatchers(DELETE, API_BASE + BOOKS).hasAuthority(ADMIN)
-            .requestMatchers(API_DOCS, SWAGGER_UI).hasAuthority(ADMIN)
+            .requestMatchers(API_DOCS, SWAGGER_UI).permitAll()
             .anyRequest().hasAnyAuthority(ADMIN, USER))
         .addFilterBefore(filterApiRequest, UsernamePasswordAuthenticationFilter.class)
         .cors(cors -> cors.configurationSource(corsConfigurationSource()))


### PR DESCRIPTION
## Summary
- Change `/swagger-ui/**` and `/v3/api-docs/**` from `.hasAuthority(ADMIN)` to `.permitAll()` in `CloudSecurityConfig`
- All API endpoints are already protected by JWT, so Swagger docs don't need additional auth gating
- Previously returned HTTP 403 for any non-admin user trying to access Swagger

## Test plan
- [ ] Visit `api.kirjaswappi.fi/swagger-ui/index.html` without auth — should load
- [ ] Verify API calls from Swagger still require JWT Bearer token