### PR TITLE
Fix: return 404 instead of 400 for missing photos

### DIFF
--- a/src/main/java/com/kirjaswappi/backend/common/http/GlobalExceptionHandler.java
+++ b/src/main/java/com/kirjaswappi/backend/common/http/GlobalExceptionHandler.java
@@ -64,6 +64,12 @@ public class GlobalExceptionHandler {
     return errorUtils.buildErrorResponse(exception, webRequest);
   }
 
+  @ExceptionHandler(PhotoNotFoundException.class)
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  public ErrorResponse handlePhotoNotFoundException(PhotoNotFoundException exception, WebRequest webRequest) {
+    return errorUtils.buildErrorResponse(exception, webRequest);
+  }
+
   @ExceptionHandler(ChatAccessDeniedException.class)
   @ResponseStatus(HttpStatus.FORBIDDEN)
   public ErrorResponse handleChatAccessDeniedException(ChatAccessDeniedException exception, WebRequest webRequest) {

--- a/src/test/java/com/kirjaswappi/backend/integration/PhotoApiIntegrationTest.java
+++ b/src/test/java/com/kirjaswappi/backend/integration/PhotoApiIntegrationTest.java
@@ -29,6 +29,7 @@ import com.kirjaswappi.backend.common.http.controllers.mockMvc.config.CustomMock
 import com.kirjaswappi.backend.http.controllers.PhotoController;
 import com.kirjaswappi.backend.service.PhotoService;
 import com.kirjaswappi.backend.service.entities.Photo;
+import com.kirjaswappi.backend.service.exceptions.PhotoNotFoundException;
 import com.kirjaswappi.backend.service.exceptions.UserNotFoundException;
 
 /**
@@ -287,6 +288,26 @@ class PhotoApiIntegrationTest {
       mockMvc.perform(multipart(API_BASE + "/cover")
           .file(imageFile)
           .param("userId", "nonexistent"))
+          .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Should return 404 when profile photo not found")
+    void shouldReturn404WhenProfilePhotoNotFound() throws Exception {
+      when(photoService.getPhotoByUserId("user-no-photo", true))
+          .thenThrow(new PhotoNotFoundException());
+
+      mockMvc.perform(get(API_BASE + "/profile/by-id/user-no-photo"))
+          .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Should return 404 when cover photo not found")
+    void shouldReturn404WhenCoverPhotoNotFound() throws Exception {
+      when(photoService.getPhotoByUserId("user-no-photo", false))
+          .thenThrow(new PhotoNotFoundException());
+
+      mockMvc.perform(get(API_BASE + "/cover/by-id/user-no-photo"))
           .andExpect(status().isNotFound());
     }
   }


### PR DESCRIPTION
## Summary
- Added a dedicated `@ExceptionHandler` for `PhotoNotFoundException` in `GlobalExceptionHandler` that returns **404 Not Found**
- Previously, `PhotoNotFoundException` fell through to the generic `BusinessException` handler which returned **400 Bad Request**
- This is consistent with how `UserNotFoundException`, `BookNotFoundException`, and `SwapRequestNotFoundException` are handled

## Test plan
- [ ] Verify `/api/v1/photos/profile/by-id/{userId}` returns 404 (not 400) for users without a profile photo
- [ ] Verify `/api/v1/photos/cover/by-id/{userId}` returns 404 (not 400) for users without a cover photo
- [ ] Verify existing photo retrieval still works for users who have photos