### PR TITLE
Fix: return 400 instead of 403 for malformed request bodies

### DIFF
--- a/src/main/java/com/kirjaswappi/backend/common/components/FilterApiRequest.java
+++ b/src/main/java/com/kirjaswappi/backend/common/components/FilterApiRequest.java
@@ -84,21 +84,24 @@ public class FilterApiRequest extends OncePerRequestFilter {
     try {
       if (jwtUtil.isUserToken(jwt)) {
         // User token: validate and set userId as principal
-        if (jwtUtil.validateUserToken(jwt)) {
-          String userId = jwtUtil.extractUserId(jwt);
-          String role = jwtUtil.extractRole(jwt);
-          List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(role));
-          UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
-              userId, null, authorities);
-          authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-          SecurityContextHolder.getContext().setAuthentication(authToken);
+        if (!jwtUtil.validateUserToken(jwt)) {
+          throw new InvalidJwtTokenException("Invalid or expired user token");
         }
+        String userId = jwtUtil.extractUserId(jwt);
+        String role = jwtUtil.extractRole(jwt);
+        List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(role));
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+            userId, null, authorities);
+        authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authToken);
       } else {
         // Admin token: validate against AdminUser
         String username = jwtUtil.extractUsername(jwt);
         AdminUser userDetails = adminUserService.getAdminUserInfo(username);
-        if (jwtUtil.validateJwtToken(jwt, userDetails))
-          setAuthentication(request, jwt, userDetails);
+        if (!jwtUtil.validateJwtToken(jwt, userDetails)) {
+          throw new InvalidJwtTokenException("Invalid or expired admin token");
+        }
+        setAuthentication(request, jwt, userDetails);
       }
     } catch (JwtException | AuthenticationException | ClassCastException e) {
       logger.warn(e.getMessage());

--- a/src/main/java/com/kirjaswappi/backend/common/configs/CloudSecurityConfig.java
+++ b/src/main/java/com/kirjaswappi/backend/common/configs/CloudSecurityConfig.java
@@ -14,10 +14,13 @@ import static org.springframework.http.HttpMethod.POST;
 import java.util.Arrays;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -33,6 +36,8 @@ import com.kirjaswappi.backend.common.components.FilterApiRequest;
 @EnableWebSecurity
 @Profile("cloud")
 public class CloudSecurityConfig {
+
+  private static final Logger logger = LoggerFactory.getLogger(CloudSecurityConfig.class);
 
   @Value("${cors.allowed-origins:https://kirjaswappi.fi,https://www.kirjaswappi.fi,https://canary.kirjaswappi.fi}")
   private String[] allowedOrigins;
@@ -74,10 +79,24 @@ public class CloudSecurityConfig {
             .requestMatchers(DELETE, API_BASE + ADMIN_USERS + USERNAME).hasAuthority(ADMIN)
             .requestMatchers(DELETE, API_BASE + SWAP_REQUESTS).hasAuthority(ADMIN)
             .requestMatchers(DELETE, API_BASE + BOOKS).hasAuthority(ADMIN)
-            .requestMatchers(API_DOCS, SWAGGER_UI).permitAll()
+            .requestMatchers(API_DOCS, SWAGGER_UI, "/error").permitAll()
             .anyRequest().hasAnyAuthority(ADMIN, USER))
         .addFilterBefore(filterApiRequest, UsernamePasswordAuthenticationFilter.class)
         .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+        .exceptionHandling(ex -> ex
+            .accessDeniedHandler((request, response, accessDeniedException) -> {
+              logger.warn("Access denied: {} {} — auth: {}, reason: {}",
+                  request.getMethod(), request.getRequestURI(),
+                  request.getHeader("Authorization") != null ? "present" : "missing",
+                  accessDeniedException.getMessage());
+              response.setStatus(HttpStatus.FORBIDDEN.value());
+            })
+            .authenticationEntryPoint((request, response, authException) -> {
+              logger.warn("Unauthenticated: {} {} — reason: {}",
+                  request.getMethod(), request.getRequestURI(),
+                  authException.getMessage());
+              response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            }))
         .build();
   }
 

--- a/src/main/java/com/kirjaswappi/backend/common/http/GlobalExceptionHandler.java
+++ b/src/main/java/com/kirjaswappi/backend/common/http/GlobalExceptionHandler.java
@@ -10,11 +10,14 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.multipart.MultipartException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 import com.kirjaswappi.backend.common.exceptions.BusinessException;
@@ -153,5 +156,30 @@ public class GlobalExceptionHandler {
   public ErrorResponse handleIllegalArgumentException(IllegalArgumentException ex) {
     log.warn("Invalid argument: {}", ex.getMessage());
     return new ErrorResponse(new ErrorResponse.Error("invalidArgument", "Invalid request argument"));
+  }
+
+  @ExceptionHandler(BindException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ErrorResponse handleBindException(BindException ex) {
+    log.warn("Request binding failed: {}", ex.getMessage());
+    var error = new ErrorResponse.Error("bindingFailed", "Request binding failed");
+    ex.getFieldErrors().forEach(fieldError -> error.addErrorDetail(
+        "invalidField", fieldError.getDefaultMessage(), fieldError.getField()));
+    return new ErrorResponse(error);
+  }
+
+  @ExceptionHandler(MultipartException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ErrorResponse handleMultipartException(MultipartException ex) {
+    log.warn("Multipart request failed: {}", ex.getMessage());
+    return new ErrorResponse(new ErrorResponse.Error("invalidMultipartRequest", "Invalid multipart request"));
+  }
+
+  @ExceptionHandler(MissingServletRequestPartException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ErrorResponse handleMissingPartException(MissingServletRequestPartException ex) {
+    log.warn("Missing request part: {}", ex.getMessage());
+    return new ErrorResponse(
+        new ErrorResponse.Error("missingRequestPart", "Required part '" + ex.getRequestPartName() + "' is missing"));
   }
 }

--- a/src/test/java/com/kirjaswappi/backend/common/components/FilterApiRequestTest.java
+++ b/src/test/java/com/kirjaswappi/backend/common/components/FilterApiRequestTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2025 KirjaSwappi or KirjaSwappi affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+package com.kirjaswappi.backend.common.components;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.kirjaswappi.backend.common.http.ErrorUtils;
+import com.kirjaswappi.backend.common.service.AdminUserService;
+import com.kirjaswappi.backend.common.service.entities.AdminUser;
+import com.kirjaswappi.backend.common.service.enums.Role;
+import com.kirjaswappi.backend.common.utils.JwtUtil;
+
+@ExtendWith(MockitoExtension.class)
+class FilterApiRequestTest {
+
+  @Mock
+  private AdminUserService adminUserService;
+  @Mock
+  private ErrorUtils errorUtils;
+  @Mock
+  private JwtUtil jwtUtil;
+  @Mock
+  private FilterChain filterChain;
+
+  @InjectMocks
+  private FilterApiRequest filterApiRequest;
+
+  private MockHttpServletRequest request;
+  private MockHttpServletResponse response;
+
+  @BeforeEach
+  void setUp() {
+    request = new MockHttpServletRequest();
+    response = new MockHttpServletResponse();
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  @DisplayName("Should continue filter chain when no JWT token is present")
+  void shouldContinueWhenNoToken() throws Exception {
+    filterApiRequest.doFilterInternal(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+    assertNull(SecurityContextHolder.getContext().getAuthentication());
+  }
+
+  @Test
+  @DisplayName("Should set authentication when user token is valid")
+  void shouldSetAuthWhenUserTokenIsValid() throws Exception {
+    request.addHeader("Authorization", "Bearer valid-user-token");
+
+    when(jwtUtil.isUserToken("valid-user-token")).thenReturn(true);
+    when(jwtUtil.validateUserToken("valid-user-token")).thenReturn(true);
+    when(jwtUtil.extractUserId("valid-user-token")).thenReturn("user-123");
+    when(jwtUtil.extractRole("valid-user-token")).thenReturn("USER");
+
+    filterApiRequest.doFilterInternal(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+    var auth = SecurityContextHolder.getContext().getAuthentication();
+    assertNotNull(auth);
+    assertEquals("user-123", auth.getName());
+    assertEquals("USER", auth.getAuthorities().iterator().next().getAuthority());
+  }
+
+  @Test
+  @DisplayName("Should return 401 when user token is invalid")
+  void shouldReturn401WhenUserTokenIsInvalid() throws Exception {
+    request.addHeader("Authorization", "Bearer expired-user-token");
+
+    when(jwtUtil.isUserToken("expired-user-token")).thenReturn(true);
+    when(jwtUtil.validateUserToken("expired-user-token")).thenReturn(false);
+    when(errorUtils.buildErrorResponse(any()))
+        .thenReturn(new com.kirjaswappi.backend.common.http.ErrorResponse(
+            new com.kirjaswappi.backend.common.http.ErrorResponse.Error("invalidJwtToken", "Invalid token")));
+
+    filterApiRequest.doFilterInternal(request, response, filterChain);
+
+    verify(filterChain, never()).doFilter(request, response);
+    assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.getStatus());
+    assertNull(SecurityContextHolder.getContext().getAuthentication());
+  }
+
+  @Test
+  @DisplayName("Should return 401 when admin token is invalid")
+  void shouldReturn401WhenAdminTokenIsInvalid() throws Exception {
+    request.addHeader("Authorization", "Bearer bad-admin-token");
+
+    when(jwtUtil.isUserToken("bad-admin-token")).thenReturn(false);
+    when(jwtUtil.extractUsername("bad-admin-token")).thenReturn("admin");
+    when(adminUserService.getAdminUserInfo("admin"))
+        .thenReturn(new AdminUser("admin", "pass", Role.ADMIN));
+    when(jwtUtil.validateJwtToken(eq("bad-admin-token"), any())).thenReturn(false);
+    when(errorUtils.buildErrorResponse(any()))
+        .thenReturn(new com.kirjaswappi.backend.common.http.ErrorResponse(
+            new com.kirjaswappi.backend.common.http.ErrorResponse.Error("invalidJwtToken", "Invalid token")));
+
+    filterApiRequest.doFilterInternal(request, response, filterChain);
+
+    verify(filterChain, never()).doFilter(request, response);
+    assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.getStatus());
+  }
+}

--- a/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/BookControllerEdgeCaseTest.java
+++ b/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/BookControllerEdgeCaseTest.java
@@ -4,6 +4,7 @@
  */
 package com.kirjaswappi.backend.http.controllers.mockMvc;
 
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -428,6 +429,103 @@ class BookControllerEdgeCaseTest {
           .param("page", "0")
           .param("size", "0"))
           .andExpect(status().isOk());
+    }
+  }
+
+  @Nested
+  @DisplayName("Malformed Request Body Cases — should return 400 not 403")
+  class MalformedRequestBodyTests {
+
+    @Test
+    @DisplayName("Should return 400 when swapCondition JSON is invalid")
+    void shouldReturn400WhenSwapConditionJsonIsInvalid() throws Exception {
+      mockMvc.perform(multipart(API_BASE)
+          .file(coverPhoto)
+          .param("title", "Test Book")
+          .param("author", "Test Author")
+          .param("language", "English")
+          .param("condition", "Good")
+          .param("genres", "Fiction")
+          .param("ownerId", "user-123")
+          .param("swapCondition", "not-valid-json"))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Should return 400 when location JSON is invalid")
+    void shouldReturn400WhenLocationJsonIsInvalid() throws Exception {
+      String swapCondition = """
+          {
+            "swapType": "GiveAway",
+            "giveAway": true,
+            "openForOffers": false
+          }
+          """;
+
+      mockMvc.perform(multipart(API_BASE)
+          .file(coverPhoto)
+          .param("title", "Test Book")
+          .param("author", "Test Author")
+          .param("language", "English")
+          .param("condition", "Good")
+          .param("genres", "Fiction")
+          .param("ownerId", "user-123")
+          .param("swapCondition", swapCondition)
+          .param("location", "not-valid-json"))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Should return 400 when no cover photo is provided")
+    void shouldReturn400WhenNoCoverPhoto() throws Exception {
+      String swapCondition = """
+          {
+            "swapType": "GiveAway",
+            "giveAway": true,
+            "openForOffers": false
+          }
+          """;
+
+      mockMvc.perform(multipart(API_BASE)
+          .param("title", "Test Book")
+          .param("author", "Test Author")
+          .param("language", "English")
+          .param("condition", "Good")
+          .param("genres", "Fiction")
+          .param("ownerId", "user-123")
+          .param("swapCondition", swapCondition))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Should return 400 when genres is empty")
+    void shouldReturn400WhenGenresEmpty() throws Exception {
+      String swapCondition = """
+          {
+            "swapType": "GiveAway",
+            "giveAway": true,
+            "openForOffers": false
+          }
+          """;
+
+      mockMvc.perform(multipart(API_BASE)
+          .file(coverPhoto)
+          .param("title", "Test Book")
+          .param("author", "Test Author")
+          .param("language", "English")
+          .param("condition", "Good")
+          .param("ownerId", "user-123")
+          .param("swapCondition", swapCondition))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Should not return 403 for malformed multipart request")
+    void shouldNotReturn403ForMalformedRequest() throws Exception {
+      // Send a multipart request with completely missing required fields
+      mockMvc.perform(multipart(API_BASE)
+          .file(coverPhoto))
+          .andExpect(result -> assertNotEquals(403, result.getResponse().getStatus()));
     }
   }
 }

--- a/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/BookControllerEdgeCaseTest.java
+++ b/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/BookControllerEdgeCaseTest.java
@@ -4,7 +4,6 @@
  */
 package com.kirjaswappi.backend.http.controllers.mockMvc;
 
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -498,8 +497,8 @@ class BookControllerEdgeCaseTest {
     }
 
     @Test
-    @DisplayName("Should return 400 when genres is empty")
-    void shouldReturn400WhenGenresEmpty() throws Exception {
+    @DisplayName("Should return 400 when genres is missing")
+    void shouldReturn400WhenGenresMissing() throws Exception {
       String swapCondition = """
           {
             "swapType": "GiveAway",
@@ -520,12 +519,11 @@ class BookControllerEdgeCaseTest {
     }
 
     @Test
-    @DisplayName("Should not return 403 for malformed multipart request")
-    void shouldNotReturn403ForMalformedRequest() throws Exception {
-      // Send a multipart request with completely missing required fields
+    @DisplayName("Should return 400 for malformed multipart request")
+    void shouldReturn400ForMalformedRequest() throws Exception {
       mockMvc.perform(multipart(API_BASE)
           .file(coverPhoto))
-          .andExpect(result -> assertNotEquals(403, result.getResponse().getStatus()));
+          .andExpect(status().isBadRequest());
     }
   }
 }


### PR DESCRIPTION
## Summary
- **FilterApiRequest**: Throw `InvalidJwtTokenException` (401) on invalid JWT instead of silently continuing, which left the user as `ANONYMOUS` and caused 403 from the authorization filter
- **CloudSecurityConfig**: Permit `/error` path so Spring's ERROR dispatch is not blocked by the authorization filter when exceptions occur during request binding
- **GlobalExceptionHandler**: Add handlers for `BindException`, `MultipartException`, and `MissingServletRequestPartException` to return 400 before they escalate to ERROR dispatch

## Test plan
- [x] `FilterApiRequestTest` — 4 tests: no token continues, valid user token sets auth, invalid user token returns 401, invalid admin token returns 401
- [x] `BookControllerEdgeCaseTest.MalformedRequestBodyTests` — 5 tests: invalid swapCondition JSON → 400, invalid location JSON → 400, missing cover photo → 400, missing genres → 400, malformed request never returns 403
- [x] All 30 tests pass, spotless clean