### PR TITLE
Add: Docker image publish to GHCR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,3 +49,32 @@ jobs:
           release_name: Release v${{ env.VERSION }}
           draft: false
           prerelease: false
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: publish_and_release
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,9 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     needs: publish_and_release
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout Repository
@@ -74,7 +77,7 @@ jobs:
           context: .
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:${{ github.sha }}
+            ghcr.io/kirjaswappi/kirjaswappi-backend:latest
+            ghcr.io/kirjaswappi/kirjaswappi-backend:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Adds a `docker` job to the main pipeline that builds and pushes a Docker image to `ghcr.io/kirjaswappi/kirjaswappi-backend` after the existing publish_and_release job
- Tags images with `latest` and the commit SHA
- Uses GitHub Actions cache for Docker layers

## Test plan
- [ ] Merge and verify the image appears at https://github.com/orgs/KirjaSwappi/packages