### PR TITLE
Fix: permit GET /api/v1/books without authentication

### DIFF
--- a/src/main/java/com/kirjaswappi/backend/common/configs/CloudSecurityConfig.java
+++ b/src/main/java/com/kirjaswappi/backend/common/configs/CloudSecurityConfig.java
@@ -75,6 +75,7 @@ public class CloudSecurityConfig {
             // Public form submissions (contact, feedback, etc.) — no auth required
             .requestMatchers(POST, API_BASE + FORMS + "/**").permitAll()
             // Public read-only endpoints (no auth required)
+            .requestMatchers(GET, API_BASE + BOOKS).permitAll()
             .requestMatchers(GET, API_BASE + BOOKS + "/**").permitAll()
             .requestMatchers(GET, API_BASE + GENRES).permitAll()
             .requestMatchers(GET, API_BASE + CITIES).permitAll()


### PR DESCRIPTION
## Summary
- Add `permitAll()` matcher for `GET /api/v1/books` base path
- The existing `BOOKS + "/**"` pattern only matches subpaths (e.g., `/api/v1/books/123`) but not the collection endpoint itself (`/api/v1/books`), causing unauthenticated browse requests to return 401

## Test plan
- [ ] Verify `GET /api/v1/books` returns 200 without auth token
- [ ] Verify `GET /api/v1/books/{id}` still works without auth
- [ ] Verify `POST /api/v1/books` still requires auth