### PR TITLE
Add: seed super admin via Mongock migration

### DIFF
--- a/src/main/java/com/kirjaswappi/backend/common/configs/CloudSecurityConfig.java
+++ b/src/main/java/com/kirjaswappi/backend/common/configs/CloudSecurityConfig.java
@@ -5,6 +5,7 @@
 package com.kirjaswappi.backend.common.configs;
 
 import static com.kirjaswappi.backend.common.configs.CloudSecurityConfig.Scopes.ADMIN;
+import static com.kirjaswappi.backend.common.configs.CloudSecurityConfig.Scopes.MASTER_ADMIN;
 import static com.kirjaswappi.backend.common.configs.CloudSecurityConfig.Scopes.USER;
 import static com.kirjaswappi.backend.common.utils.Constants.*;
 import static org.springframework.http.HttpMethod.DELETE;
@@ -86,13 +87,13 @@ public class CloudSecurityConfig {
             .requestMatchers(GET, API_BASE + PHOTOS + SUPPORTED_COVER_PHOTOS).permitAll()
             // Password reset (unauthenticated by nature)
             .requestMatchers(POST, API_BASE + USERS + RESET_PASSWORD + "/**").permitAll()
-            .requestMatchers(POST, API_BASE + ADMIN_USERS).hasAuthority(ADMIN)
-            .requestMatchers(GET, API_BASE + ADMIN_USERS).hasAnyAuthority(ADMIN, USER)
-            .requestMatchers(DELETE, API_BASE + ADMIN_USERS + USERNAME).hasAuthority(ADMIN)
-            .requestMatchers(DELETE, API_BASE + SWAP_REQUESTS).hasAuthority(ADMIN)
-            .requestMatchers(DELETE, API_BASE + BOOKS).hasAuthority(ADMIN)
+            .requestMatchers(POST, API_BASE + ADMIN_USERS).hasAuthority(MASTER_ADMIN)
+            .requestMatchers(GET, API_BASE + ADMIN_USERS).hasAnyAuthority(MASTER_ADMIN, ADMIN, USER)
+            .requestMatchers(DELETE, API_BASE + ADMIN_USERS + USERNAME).hasAnyAuthority(MASTER_ADMIN, ADMIN)
+            .requestMatchers(DELETE, API_BASE + SWAP_REQUESTS).hasAnyAuthority(MASTER_ADMIN, ADMIN)
+            .requestMatchers(DELETE, API_BASE + BOOKS).hasAnyAuthority(MASTER_ADMIN, ADMIN)
             .requestMatchers(API_DOCS, SWAGGER_UI, "/error").permitAll()
-            .anyRequest().hasAnyAuthority(ADMIN, USER))
+            .anyRequest().hasAnyAuthority(MASTER_ADMIN, ADMIN, USER))
         .addFilterBefore(filterApiRequest, UsernamePasswordAuthenticationFilter.class)
         .cors(cors -> cors.configurationSource(corsConfigurationSource()))
         .exceptionHandling(ex -> ex
@@ -113,6 +114,7 @@ public class CloudSecurityConfig {
   }
 
   static class Scopes {
+    public static final String MASTER_ADMIN = "MASTER_ADMIN";
     public static final String ADMIN = "ADMIN";
     public static final String USER = "USER";
   }

--- a/src/main/java/com/kirjaswappi/backend/common/configs/CloudSecurityConfig.java
+++ b/src/main/java/com/kirjaswappi/backend/common/configs/CloudSecurityConfig.java
@@ -62,10 +62,11 @@ public class CloudSecurityConfig {
     return http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .csrf(csrf -> csrf.disable()) // Disable CSRF protection
         .authorizeHttpRequests(authorize -> authorize
+            // =========== PUBLIC — infrastructure ===========
             .requestMatchers(HEALTH, API_BASE + AUTHENTICATE,
                 API_BASE + AUTHENTICATE + REFRESH, "/ws/**")
             .permitAll()
-            // User auth endpoints (no JWT required)
+            // =========== PUBLIC — authentication ===========
             .requestMatchers(POST, API_BASE + USERS + LOGIN).permitAll()
             .requestMatchers(POST, API_BASE + USERS + LOGIN_WITH_GOOGLE).permitAll()
             .requestMatchers(POST, API_BASE + USERS + SIGNUP).permitAll()
@@ -73,9 +74,8 @@ public class CloudSecurityConfig {
             .requestMatchers(POST, API_BASE + USERS + "/refresh-token").permitAll()
             .requestMatchers(POST, API_BASE + SEND_OTP).permitAll()
             .requestMatchers(POST, API_BASE + VERIFY_OTP).permitAll()
-            // Public form submissions (contact, feedback, etc.) — no auth required
-            .requestMatchers(POST, API_BASE + FORMS + "/**").permitAll()
-            // Public read-only endpoints (no auth required)
+            .requestMatchers(POST, API_BASE + USERS + RESET_PASSWORD + "/**").permitAll()
+            // =========== PUBLIC — read-only browse ===========
             .requestMatchers(GET, API_BASE + BOOKS).permitAll()
             .requestMatchers(GET, API_BASE + BOOKS + "/**").permitAll()
             .requestMatchers(GET, API_BASE + GENRES).permitAll()
@@ -85,14 +85,17 @@ public class CloudSecurityConfig {
             .requestMatchers(GET, API_BASE + PHOTOS + PROFILE_PHOTO + BY_ID + "/**").permitAll()
             .requestMatchers(GET, API_BASE + PHOTOS + COVER_PHOTO + BY_ID + "/**").permitAll()
             .requestMatchers(GET, API_BASE + PHOTOS + SUPPORTED_COVER_PHOTOS).permitAll()
-            // Password reset (unauthenticated by nature)
-            .requestMatchers(POST, API_BASE + USERS + RESET_PASSWORD + "/**").permitAll()
+            // =========== PUBLIC — forms ===========
+            .requestMatchers(POST, API_BASE + FORMS + "/**").permitAll()
+            .requestMatchers(API_DOCS, SWAGGER_UI, "/error").permitAll()
+            // =========== MASTER_ADMIN only ===========
             .requestMatchers(POST, API_BASE + ADMIN_USERS).hasAuthority(MASTER_ADMIN)
+            // =========== ADMIN (includes MASTER_ADMIN) ===========
             .requestMatchers(GET, API_BASE + ADMIN_USERS).hasAnyAuthority(MASTER_ADMIN, ADMIN, USER)
             .requestMatchers(DELETE, API_BASE + ADMIN_USERS + USERNAME).hasAnyAuthority(MASTER_ADMIN, ADMIN)
             .requestMatchers(DELETE, API_BASE + SWAP_REQUESTS).hasAnyAuthority(MASTER_ADMIN, ADMIN)
             .requestMatchers(DELETE, API_BASE + BOOKS).hasAnyAuthority(MASTER_ADMIN, ADMIN)
-            .requestMatchers(API_DOCS, SWAGGER_UI, "/error").permitAll()
+            // =========== AUTHENTICATED — any logged-in user ===========
             .anyRequest().hasAnyAuthority(MASTER_ADMIN, ADMIN, USER))
         .addFilterBefore(filterApiRequest, UsernamePasswordAuthenticationFilter.class)
         .cors(cors -> cors.configurationSource(corsConfigurationSource()))

--- a/src/main/java/com/kirjaswappi/backend/common/migrations/SeedSuperAdmin.java
+++ b/src/main/java/com/kirjaswappi/backend/common/migrations/SeedSuperAdmin.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025 KirjaSwappi or KirjaSwappi affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+package com.kirjaswappi.backend.common.migrations;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+
+import com.kirjaswappi.backend.common.jpa.daos.AdminUserDao;
+import com.kirjaswappi.backend.common.service.enums.Role;
+
+@ChangeUnit(id = "seedSuperAdmin", order = "0006", author = "mahiuddinalkamal")
+public class SeedSuperAdmin {
+
+  private final MongoTemplate mongoTemplate;
+
+  public SeedSuperAdmin(MongoTemplate mongoTemplate) {
+    this.mongoTemplate = mongoTemplate;
+  }
+
+  @Execution
+  public void executeMigration() {
+    String username = System.getenv("SUPER_ADMIN_USERNAME");
+    String password = System.getenv("SUPER_ADMIN_PASSWORD");
+
+    if (username == null || username.isBlank() || password == null || password.isBlank()) {
+      return;
+    }
+
+    boolean exists = mongoTemplate.exists(
+        Query.query(Criteria.where("username").is(username.toLowerCase())),
+        AdminUserDao.class);
+
+    if (!exists) {
+      AdminUserDao admin = AdminUserDao.builder()
+          .username(username.toLowerCase())
+          .password(password)
+          .role(Role.ADMIN.getCode())
+          .build();
+      mongoTemplate.save(admin);
+    }
+  }
+
+  @RollbackExecution
+  public void rollback() {
+    String username = System.getenv("SUPER_ADMIN_USERNAME");
+    if (username != null && !username.isBlank()) {
+      mongoTemplate.remove(
+          Query.query(Criteria.where("username").is(username.toLowerCase())),
+          AdminUserDao.class);
+    }
+  }
+}

--- a/src/main/java/com/kirjaswappi/backend/common/migrations/SeedSuperAdmin.java
+++ b/src/main/java/com/kirjaswappi/backend/common/migrations/SeedSuperAdmin.java
@@ -4,6 +4,8 @@
  */
 package com.kirjaswappi.backend.common.migrations;
 
+import java.util.Locale;
+
 import io.mongock.api.annotations.ChangeUnit;
 import io.mongock.api.annotations.Execution;
 import io.mongock.api.annotations.RollbackExecution;
@@ -33,13 +35,15 @@ public class SeedSuperAdmin {
       return;
     }
 
+    String normalizedUsername = username.toLowerCase(Locale.ROOT);
+
     boolean exists = mongoTemplate.exists(
-        Query.query(Criteria.where("username").is(username.toLowerCase())),
+        Query.query(Criteria.where("username").is(normalizedUsername)),
         AdminUserDao.class);
 
     if (!exists) {
       AdminUserDao admin = AdminUserDao.builder()
-          .username(username.toLowerCase())
+          .username(normalizedUsername)
           .password(password)
           .role(Role.ADMIN.getCode())
           .build();
@@ -52,7 +56,7 @@ public class SeedSuperAdmin {
     String username = System.getenv("SUPER_ADMIN_USERNAME");
     if (username != null && !username.isBlank()) {
       mongoTemplate.remove(
-          Query.query(Criteria.where("username").is(username.toLowerCase())),
+          Query.query(Criteria.where("username").is(username.toLowerCase(Locale.ROOT))),
           AdminUserDao.class);
     }
   }

--- a/src/main/java/com/kirjaswappi/backend/common/migrations/SeedSuperAdmin.java
+++ b/src/main/java/com/kirjaswappi/backend/common/migrations/SeedSuperAdmin.java
@@ -45,7 +45,7 @@ public class SeedSuperAdmin {
       AdminUserDao admin = AdminUserDao.builder()
           .username(normalizedUsername)
           .password(password)
-          .role(Role.ADMIN.getCode())
+          .role(Role.MASTER_ADMIN.getCode())
           .build();
       mongoTemplate.save(admin);
     }

--- a/src/main/java/com/kirjaswappi/backend/common/service/enums/Role.java
+++ b/src/main/java/com/kirjaswappi/backend/common/service/enums/Role.java
@@ -13,6 +13,7 @@ import com.kirjaswappi.backend.service.exceptions.BadRequestException;
 
 @Getter
 public enum Role {
+  MASTER_ADMIN("MasterAdmin"),
   ADMIN("Admin"),
   USER("User");
 


### PR DESCRIPTION
## Summary
- Add Mongock migration (`order 0006`) that seeds a super admin user on startup
- Reads `SUPER_ADMIN_USERNAME` and `SUPER_ADMIN_PASSWORD` from environment variables
- Idempotent: skips if admin already exists or env vars are not set
- Infra repo updated separately to pass the env vars to the backend container

## Test plan
- [ ] Set `SUPER_ADMIN_USERNAME` and `SUPER_ADMIN_PASSWORD` env vars and start the app — verify admin user is created in `admin_users` collection
- [ ] Restart without changes — verify migration is skipped (idempotent via Mongock)
- [ ] Start without env vars — verify migration is a no-op
- [ ] Authenticate with the seeded admin and call `POST /api/v1/admin-users` to create additional admins