### PR TITLE
Pre-launch audit: harden auth, fix swap/chat/notification correctness, gate CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,39 @@
 version: 2
 updates:
-  # Enable version updates for Maven package
-  - package-ecosystem: "maven"
-    directory: "/" # Location of package manifests
+  - package-ecosystem: maven
+    directory: /
     schedule:
-      interval: "weekly"
-  
-  # Enable version updates for Docker
-  - package-ecosystem: "docker"
-    directory: "/"
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: 'Build(deps)'
+    labels:
+      - dependencies
+    groups:
+      spring:
+        patterns:
+          - 'org.springframework.boot:*'
+          - 'org.springframework.cloud:*'
+          - 'org.springframework.security:*'
+      grpc:
+        patterns:
+          - 'io.grpc:*'
+
+  - package-ecosystem: docker
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+    commit-message:
+      prefix: 'Build(deps)'
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: 'Build(deps)'
+    labels:
+      - dependencies

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (Java)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: java
+          queries: security-and-quality
+      - name: Build (skip tests for CodeQL)
+        run: mvn -B -DskipTests -q package
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:java'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,11 +28,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Build Package (skip tests)
-        run: mvn clean package -DskipTests
-
-      - name: Deploy to GitHub Packages
-        run: mvn deploy -s .github/mvn/settings.xml -DskipTests
+      - name: Build, run tests, deploy
+        run: mvn -B deploy -s .github/mvn/settings.xml
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,14 +5,13 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  packages: write
-
 jobs:
   publish_and_release:
     runs-on: ubuntu-latest
     container: maven:3-sapmachine-25
+    permissions:
+      contents: write
+      packages: write
 
     steps:
       - name: Checkout Repository
@@ -21,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Maven cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /root/.m2
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -38,12 +37,10 @@ jobs:
         run: echo "VERSION=0.0.${{ github.run_number }}" >> $GITHUB_ENV
 
       - name: Create GitHub Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ env.VERSION }}
-          release_name: Release v${{ env.VERSION }}
+          name: Release v${{ env.VERSION }}
           draft: false
           prerelease: false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,36 @@
-FROM maven:3-sapmachine-25
+################ Build stage ################
+FROM maven:3-sapmachine-25 AS builder
+
+WORKDIR /build
+
+# Cache dependencies first.
+COPY pom.xml ./
+COPY .mvn .mvn
+COPY mvnw mvnw.cmd ./
+RUN mvn -B -q dependency:go-offline
+
+# Copy sources and build.
+COPY src src
+COPY eclipse-formatter-profile.xml eclipse.importorder license-header ./
+RUN mvn -B -q -DskipTests package \
+    && cp target/backend-*-SNAPSHOT.jar /build/app.jar
+
+################ Runtime stage ################
+FROM eclipse-temurin:25-jre
+
+# Create non-root user with stable UID/GID.
+RUN groupadd --system --gid 1001 kirja \
+    && useradd --system --uid 1001 --gid 1001 --shell /usr/sbin/nologin kirja
 
 WORKDIR /app
+COPY --from=builder --chown=kirja:kirja /build/app.jar /app/app.jar
 
-COPY . .
+USER 1001
 
-RUN mvn package -DskipTests
+ENV SPRING_PROFILES_ACTIVE=cloud \
+    PORT=10000 \
+    JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=75 -XX:+UseG1GC"
 
-ENV SPRING_PROFILES_ACTIVE=cloud
-ENV PORT=10000
 EXPOSE 10000
 
-CMD ["java", "-jar", "target/backend-1.0.0-SNAPSHOT.jar"]
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ################ Build stage ################
-FROM maven:3-sapmachine-25 AS builder
+FROM maven:3.9.9-sapmachine-25 AS builder
 
 WORKDIR /build
 
@@ -16,7 +16,7 @@ RUN mvn -B -q -DskipTests package \
     && cp target/backend-*-SNAPSHOT.jar /build/app.jar
 
 ################ Runtime stage ################
-FROM eclipse-temurin:25-jre
+FROM eclipse-temurin:25-jre-noble
 
 # Create non-root user with stable UID/GID.
 RUN groupadd --system --gid 1001 kirja \

--- a/src/main/java/com/kirjaswappi/backend/BackendApplication.java
+++ b/src/main/java/com/kirjaswappi/backend/BackendApplication.java
@@ -29,7 +29,8 @@ public class BackendApplication {
     // production (KIRJASWAPPI_PRODUCTION=true) but the active profile is
     // not 'cloud', fail fast — LocalSecurityConfig disables all security.
     String productionFlag = System.getenv("KIRJASWAPPI_PRODUCTION");
-    if ("true".equalsIgnoreCase(productionFlag) && !activeProfile.contains("cloud")) {
+    if ("true".equalsIgnoreCase(productionFlag)
+        && !java.util.Arrays.asList(activeProfile.split(",")).contains("cloud")) {
       log.error("Refusing to start: KIRJASWAPPI_PRODUCTION=true but active profile '{}' does not include 'cloud'. "
           + "LocalSecurityConfig disables authentication; running with this combination would expose the API.",
           activeProfile);

--- a/src/main/java/com/kirjaswappi/backend/BackendApplication.java
+++ b/src/main/java/com/kirjaswappi/backend/BackendApplication.java
@@ -20,13 +20,36 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class BackendApplication {
 
   public static void main(String[] args) {
-    String activeProfile = System.getProperty("spring.profiles.active", "default");
+    String activeProfile = resolveActiveProfile();
 
     log.info("*** KirjaSwappi Backend ***");
     log.info("Running on {} profile", activeProfile);
 
+    // Production deploy guard. If the deploy environment marks itself as
+    // production (KIRJASWAPPI_PRODUCTION=true) but the active profile is
+    // not 'cloud', fail fast — LocalSecurityConfig disables all security.
+    String productionFlag = System.getenv("KIRJASWAPPI_PRODUCTION");
+    if ("true".equalsIgnoreCase(productionFlag) && !activeProfile.contains("cloud")) {
+      log.error("Refusing to start: KIRJASWAPPI_PRODUCTION=true but active profile '{}' does not include 'cloud'. "
+          + "LocalSecurityConfig disables authentication; running with this combination would expose the API.",
+          activeProfile);
+      System.exit(78); // EX_CONFIG
+    }
+
     SpringApplication.run(BackendApplication.class, args);
 
     log.info("Application started successfully");
+  }
+
+  private static String resolveActiveProfile() {
+    String fromProperty = System.getProperty("spring.profiles.active");
+    if (fromProperty != null && !fromProperty.isBlank()) {
+      return fromProperty;
+    }
+    String fromEnv = System.getenv("SPRING_PROFILES_ACTIVE");
+    if (fromEnv != null && !fromEnv.isBlank()) {
+      return fromEnv;
+    }
+    return "default";
   }
 }

--- a/src/main/java/com/kirjaswappi/backend/common/configs/CloudSecurityConfig.java
+++ b/src/main/java/com/kirjaswappi/backend/common/configs/CloudSecurityConfig.java
@@ -11,6 +11,7 @@ import static com.kirjaswappi.backend.common.utils.Constants.*;
 import static org.springframework.http.HttpMethod.DELETE;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpMethod.PUT;
 
 import java.util.Arrays;
 import java.util.List;
@@ -80,21 +81,33 @@ public class CloudSecurityConfig {
             .requestMatchers(GET, API_BASE + BOOKS + "/**").permitAll()
             .requestMatchers(GET, API_BASE + GENRES).permitAll()
             .requestMatchers(GET, API_BASE + CITIES).permitAll()
-            .requestMatchers(GET, API_BASE + USERS + ID).permitAll()
             .requestMatchers(GET, API_BASE + USERS + ID + BOOKS).permitAll()
             .requestMatchers(GET, API_BASE + PHOTOS + PROFILE_PHOTO + BY_ID + "/**").permitAll()
             .requestMatchers(GET, API_BASE + PHOTOS + COVER_PHOTO + BY_ID + "/**").permitAll()
             .requestMatchers(GET, API_BASE + PHOTOS + SUPPORTED_COVER_PHOTOS).permitAll()
             // =========== PUBLIC — forms ===========
             .requestMatchers(POST, API_BASE + FORMS + "/**").permitAll()
-            .requestMatchers(API_DOCS, SWAGGER_UI, "/error").permitAll()
+            .requestMatchers("/error").permitAll()
+            // =========== Disable Swagger / OpenAPI in cloud profile ===========
+            .requestMatchers(API_DOCS, SWAGGER_UI).denyAll()
             // =========== MASTER_ADMIN only ===========
             .requestMatchers(POST, API_BASE + ADMIN_USERS).hasAuthority(MASTER_ADMIN)
             // =========== ADMIN (includes MASTER_ADMIN) ===========
-            .requestMatchers(GET, API_BASE + ADMIN_USERS).hasAnyAuthority(MASTER_ADMIN, ADMIN, USER)
+            .requestMatchers(GET, API_BASE + ADMIN_USERS).hasAnyAuthority(MASTER_ADMIN, ADMIN)
+            .requestMatchers(GET, API_BASE + USERS).hasAnyAuthority(MASTER_ADMIN, ADMIN)
             .requestMatchers(DELETE, API_BASE + ADMIN_USERS + USERNAME).hasAnyAuthority(MASTER_ADMIN, ADMIN)
             .requestMatchers(DELETE, API_BASE + SWAP_REQUESTS).hasAnyAuthority(MASTER_ADMIN, ADMIN)
             .requestMatchers(DELETE, API_BASE + BOOKS).hasAnyAuthority(MASTER_ADMIN, ADMIN)
+            // Genre taxonomy mutations: admins only
+            .requestMatchers(POST, API_BASE + GENRES).hasAnyAuthority(MASTER_ADMIN, ADMIN)
+            .requestMatchers(POST, API_BASE + GENRES + "/**").hasAnyAuthority(MASTER_ADMIN, ADMIN)
+            .requestMatchers(PUT, API_BASE + GENRES + "/**").hasAnyAuthority(MASTER_ADMIN, ADMIN)
+            .requestMatchers(DELETE, API_BASE + GENRES + "/**").hasAnyAuthority(MASTER_ADMIN, ADMIN)
+            // Supported cover photos catalog: admins only
+            .requestMatchers(POST, API_BASE + PHOTOS + SUPPORTED_COVER_PHOTOS)
+            .hasAnyAuthority(MASTER_ADMIN, ADMIN)
+            .requestMatchers(DELETE, API_BASE + PHOTOS + SUPPORTED_COVER_PHOTOS + "/**")
+            .hasAnyAuthority(MASTER_ADMIN, ADMIN)
             // =========== AUTHENTICATED — any logged-in user ===========
             .anyRequest().hasAnyAuthority(MASTER_ADMIN, ADMIN, USER))
         .addFilterBefore(filterApiRequest, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/kirjaswappi/backend/common/configs/CloudSecurityConfig.java
+++ b/src/main/java/com/kirjaswappi/backend/common/configs/CloudSecurityConfig.java
@@ -75,7 +75,7 @@ public class CloudSecurityConfig {
             .requestMatchers(POST, API_BASE + USERS + "/refresh-token").permitAll()
             .requestMatchers(POST, API_BASE + SEND_OTP).permitAll()
             .requestMatchers(POST, API_BASE + VERIFY_OTP).permitAll()
-            .requestMatchers(POST, API_BASE + USERS + RESET_PASSWORD + "/**").permitAll()
+            .requestMatchers(POST, API_BASE + USERS + RESET_PASSWORD + "/{email}").permitAll()
             // =========== PUBLIC — read-only browse ===========
             .requestMatchers(GET, API_BASE + BOOKS).permitAll()
             .requestMatchers(GET, API_BASE + BOOKS + "/**").permitAll()

--- a/src/main/java/com/kirjaswappi/backend/common/configs/WebSocketSecurityConfig.java
+++ b/src/main/java/com/kirjaswappi/backend/common/configs/WebSocketSecurityConfig.java
@@ -22,8 +22,6 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
-import com.kirjaswappi.backend.common.service.AdminUserService;
-import com.kirjaswappi.backend.common.service.entities.AdminUser;
 import com.kirjaswappi.backend.common.utils.JwtUtil;
 
 @Configuration
@@ -32,9 +30,6 @@ public class WebSocketSecurityConfig implements WebSocketMessageBrokerConfigurer
 
   @Autowired
   private JwtUtil jwtUtil;
-
-  @Autowired
-  private AdminUserService adminUserService;
 
   @Override
   public void configureClientInboundChannel(ChannelRegistration registration) {
@@ -53,32 +48,21 @@ public class WebSocketSecurityConfig implements WebSocketMessageBrokerConfigurer
           String jwt = authHeader.substring(7);
 
           try {
-            if (jwtUtil.isUserToken(jwt)) {
-              // User token: extract userId from token claims
-              if (!jwtUtil.validateUserToken(jwt)) {
-                throw new IllegalArgumentException("Invalid user JWT token");
-              }
-              String userId = jwtUtil.extractUserId(jwt);
-              String role = jwtUtil.extractRole(jwt);
-              List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(role));
-              Authentication auth = new UsernamePasswordAuthenticationToken(userId, null, authorities);
-              accessor.setUser(auth);
-            } else {
-              // Admin token: validate against AdminUser, use userId header for routing
-              String userId = accessor.getFirstNativeHeader("userId");
-              if (userId == null || userId.trim().isEmpty()) {
-                throw new IllegalArgumentException("userId header is required for admin token WebSocket connection");
-              }
-              String username = jwtUtil.extractUsername(jwt);
-              AdminUser adminUser = adminUserService.getAdminUserInfo(username);
-              if (!jwtUtil.validateJwtToken(jwt, adminUser)) {
-                throw new IllegalArgumentException("Invalid admin JWT token");
-              }
-              String role = jwtUtil.extractRole(jwt);
-              List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(role));
-              Authentication auth = new UsernamePasswordAuthenticationToken(userId, null, authorities);
-              accessor.setUser(auth);
+            // Only end-user JWTs may connect to the application WebSocket.
+            // Admin JWTs are not allowed: principals on STOMP destinations
+            // are derived from the token subject, so trusting a client-supplied
+            // userId header from an admin token enables impersonation of any user.
+            if (!jwtUtil.isUserToken(jwt)) {
+              throw new IllegalArgumentException("Admin JWT cannot be used for application WebSocket");
             }
+            if (!jwtUtil.validateUserToken(jwt)) {
+              throw new IllegalArgumentException("Invalid user JWT token");
+            }
+            String userId = jwtUtil.extractUserId(jwt);
+            String role = jwtUtil.extractRole(jwt);
+            List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(role));
+            Authentication auth = new UsernamePasswordAuthenticationToken(userId, null, authorities);
+            accessor.setUser(auth);
 
           } catch (Exception e) {
             throw new IllegalArgumentException("WebSocket authentication failed: " + e.getMessage(), e);

--- a/src/main/java/com/kirjaswappi/backend/common/http/GlobalExceptionHandler.java
+++ b/src/main/java/com/kirjaswappi/backend/common/http/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import static com.kirjaswappi.backend.common.utils.PathProvider.getCurrentPath;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
@@ -181,5 +182,13 @@ public class GlobalExceptionHandler {
     log.warn("Missing request part: {}", ex.getMessage());
     return new ErrorResponse(
         new ErrorResponse.Error("missingRequestPart", "Required part '" + ex.getRequestPartName() + "' is missing"));
+  }
+
+  @ExceptionHandler(OptimisticLockingFailureException.class)
+  @ResponseStatus(HttpStatus.CONFLICT)
+  public ErrorResponse handleOptimisticLockingFailure(OptimisticLockingFailureException ex) {
+    log.warn("Optimistic locking conflict: {}", ex.getMessage());
+    return new ErrorResponse(new ErrorResponse.Error("conflictingUpdate",
+        "The resource was modified concurrently. Please refresh and try again."));
   }
 }

--- a/src/main/java/com/kirjaswappi/backend/common/service/NotificationService.java
+++ b/src/main/java/com/kirjaswappi/backend/common/service/NotificationService.java
@@ -9,8 +9,10 @@ import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import io.grpc.CallCredentials;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
 import io.grpc.StatusRuntimeException;
 
 import org.slf4j.Logger;
@@ -36,10 +38,14 @@ public class NotificationService implements NotificationClient {
   private static final String STATUS_FAILED = "FAILED";
   private static final int MAX_RETRIES = 3;
   private static final Duration FAILED_RETENTION = Duration.ofDays(7);
+  private static final Duration SENT_RETENTION = Duration.ofDays(14);
   private static final long CLEANUP_INTERVAL_MS = 86_400_000L; // 1 day
 
   @Autowired
   private NotificationOutboxRepository notificationOutboxRepository;
+
+  private static final Metadata.Key<String> API_KEY_METADATA_KEY = Metadata.Key.of("x-api-key",
+      Metadata.ASCII_STRING_MARSHALLER);
 
   private final ManagedChannel channel;
   private final NotificationServiceGrpc.NotificationServiceBlockingStub stub;
@@ -48,7 +54,8 @@ public class NotificationService implements NotificationClient {
   public NotificationService(
       @Value("${notification.service.host}") String host,
       @Value("${notification.service.port}") int port,
-      @Value("${notification.service.enabled:true}") boolean enabled) {
+      @Value("${notification.service.enabled:true}") boolean enabled,
+      @Value("${notification.service.apiKey:}") String apiKey) {
 
     this.enabled = enabled;
 
@@ -60,13 +67,36 @@ public class NotificationService implements NotificationClient {
           .keepAliveWithoutCalls(true)
           .build();
 
-      this.stub = NotificationServiceGrpc.newBlockingStub(channel);
-      logger.info("Notification service client initialized for {}:{}", host, port);
+      var bareStub = NotificationServiceGrpc.newBlockingStub(channel);
+      if (apiKey != null && !apiKey.isBlank()) {
+        this.stub = bareStub.withCallCredentials(apiKeyCallCredentials(apiKey));
+        logger.info("Notification service client initialized for {}:{} (with API key auth)", host, port);
+      } else {
+        this.stub = bareStub;
+        logger.warn("Notification service client initialized for {}:{} WITHOUT API key — gRPC auth disabled",
+            host, port);
+      }
     } else {
       this.channel = null;
       this.stub = null;
       logger.info("Notification service is disabled");
     }
+  }
+
+  /**
+   * Visible for testing. Builds a {@link CallCredentials} that applies the
+   * {@code x-api-key} metadata header on every outgoing call.
+   */
+  static CallCredentials apiKeyCallCredentials(String apiKey) {
+    return new CallCredentials() {
+      @Override
+      public void applyRequestMetadata(RequestInfo requestInfo, java.util.concurrent.Executor appExecutor,
+          MetadataApplier applier) {
+        Metadata headers = new Metadata();
+        headers.put(API_KEY_METADATA_KEY, apiKey);
+        applier.apply(headers);
+      }
+    };
   }
 
   @Override
@@ -162,9 +192,19 @@ public class NotificationService implements NotificationClient {
       return;
     }
 
-    Instant cutoff = Instant.now().minus(FAILED_RETENTION);
-    long deleted = notificationOutboxRepository.deleteByStatusAndCreatedAtBefore(STATUS_FAILED, cutoff);
-    logger.debug("Cleaned up {} FAILED notifications older than {} days", deleted, FAILED_RETENTION.toDays());
+    Instant failedCutoff = Instant.now().minus(FAILED_RETENTION);
+    long failedDeleted = notificationOutboxRepository
+        .deleteByStatusAndCreatedAtBefore(STATUS_FAILED, failedCutoff);
+    logger.debug("Cleaned up {} FAILED notifications older than {} days",
+        failedDeleted, FAILED_RETENTION.toDays());
+
+    // SENT notifications also accumulate forever otherwise. Keep a fortnight
+    // for ad-hoc debugging then prune so the outbox does not bloat MongoDB.
+    Instant sentCutoff = Instant.now().minus(SENT_RETENTION);
+    long sentDeleted = notificationOutboxRepository
+        .deleteByStatusAndCreatedAtBefore(STATUS_SENT, sentCutoff);
+    logger.debug("Cleaned up {} SENT notifications older than {} days",
+        sentDeleted, SENT_RETENTION.toDays());
   }
 
   @Override

--- a/src/main/java/com/kirjaswappi/backend/common/service/NotificationService.java
+++ b/src/main/java/com/kirjaswappi/backend/common/service/NotificationService.java
@@ -55,17 +55,20 @@ public class NotificationService implements NotificationClient {
       @Value("${notification.service.host}") String host,
       @Value("${notification.service.port}") int port,
       @Value("${notification.service.enabled:true}") boolean enabled,
-      @Value("${notification.service.apiKey:}") String apiKey) {
+      @Value("${notification.service.apiKey:}") String apiKey,
+      @Value("${notification.service.useTls:false}") boolean useTls) {
 
     this.enabled = enabled;
 
     if (enabled) {
-      this.channel = ManagedChannelBuilder.forAddress(host, port)
-          .usePlaintext()
+      var builder = ManagedChannelBuilder.forAddress(host, port)
           .keepAliveTime(30, TimeUnit.SECONDS)
           .keepAliveTimeout(5, TimeUnit.SECONDS)
-          .keepAliveWithoutCalls(true)
-          .build();
+          .keepAliveWithoutCalls(true);
+      if (!useTls) {
+        builder.usePlaintext();
+      }
+      this.channel = builder.build();
 
       var bareStub = NotificationServiceGrpc.newBlockingStub(channel);
       if (apiKey != null && !apiKey.isBlank()) {

--- a/src/main/java/com/kirjaswappi/backend/common/service/OTPService.java
+++ b/src/main/java/com/kirjaswappi/backend/common/service/OTPService.java
@@ -22,7 +22,6 @@ import com.kirjaswappi.backend.common.service.mappers.OTPMapper;
 import com.kirjaswappi.backend.service.UserService;
 import com.kirjaswappi.backend.service.exceptions.BadRequestException;
 import com.kirjaswappi.backend.service.exceptions.ResourceNotFoundException;
-import com.kirjaswappi.backend.service.exceptions.UserNotFoundException;
 
 @Service
 @Transactional
@@ -64,7 +63,7 @@ public class OTPService {
     String rateLimitKey = VERIFY_RATE_LIMIT_PREFIX + otp.email();
 
     // Rate limit OTP verification attempts
-    if (rateLimiterService.isRateLimited(rateLimitKey, MAX_VERIFY_ATTEMPTS)) {
+    if (rateLimiterService.isRateLimitedFailClosed(rateLimitKey, MAX_VERIFY_ATTEMPTS)) {
       throw new BadRequestException("tooManyVerifyAttempts", otp.email());
     }
 
@@ -100,16 +99,19 @@ public class OTPService {
     String rateLimitKey = SEND_RATE_LIMIT_PREFIX + email;
 
     // Rate limit OTP send attempts (applied regardless of user existence)
-    if (rateLimiterService.isRateLimited(rateLimitKey, MAX_SEND_ATTEMPTS)) {
+    if (rateLimiterService.isRateLimitedFailClosed(rateLimitKey, MAX_SEND_ATTEMPTS)) {
       throw new BadRequestException("tooManySendOtpAttempts", email);
     }
 
     // Record the attempt before checking user existence to prevent enumeration
     rateLimiterService.recordAttempt(rateLimitKey, RATE_LIMIT_WINDOW);
 
-    // Check if the user exists:
+    // Account-enumeration mitigation: behave the same way for known and unknown
+    // emails. We always return success; for unknown emails we silently no-op
+    // (no OTP saved, no email sent) so timing and response shape do not leak
+    // whether the address has an account.
     if (!checkUserExists(email)) {
-      throw new UserNotFoundException(email);
+      return email;
     }
 
     // Delete all the previous OTPs:

--- a/src/main/java/com/kirjaswappi/backend/common/service/OTPService.java
+++ b/src/main/java/com/kirjaswappi/backend/common/service/OTPService.java
@@ -70,7 +70,9 @@ public class OTPService {
     var otpEntity = this.getOTP(otp.email());
 
     // check provided OTP with the stored OTP:
-    if (!otpEntity.otp().equals(otp.otp())) {
+    if (!java.security.MessageDigest.isEqual(
+        otpEntity.otp().getBytes(java.nio.charset.StandardCharsets.UTF_8),
+        otp.otp().getBytes(java.nio.charset.StandardCharsets.UTF_8))) {
       rateLimiterService.recordAttempt(rateLimitKey, RATE_LIMIT_WINDOW);
       throw new BadRequestException("otpDoesNotMatch", otp);
     }

--- a/src/main/java/com/kirjaswappi/backend/common/service/RateLimiterService.java
+++ b/src/main/java/com/kirjaswappi/backend/common/service/RateLimiterService.java
@@ -19,6 +19,11 @@ public class RateLimiterService {
 
   private final StringRedisTemplate redisTemplate;
 
+  /**
+   * Returns true if the key has reached or exceeded {@code maxAttempts}. When
+   * Redis is unavailable, defaults to <strong>fail-open</strong> (returns false).
+   * Suitable for non-security-critical counters.
+   */
   public boolean isRateLimited(String key, int maxAttempts) {
     try {
       String value = redisTemplate.opsForValue().get(key);
@@ -29,6 +34,26 @@ public class RateLimiterService {
     } catch (Exception e) {
       log.warn("Redis unavailable for rate limit check, allowing request: {}", e.getMessage());
       return false;
+    }
+  }
+
+  /**
+   * Same as {@link #isRateLimited(String, int)} but <strong>fails
+   * closed</strong>: when Redis is unavailable we treat the request as
+   * rate-limited so brute-force protections cannot be bypassed by knocking Redis
+   * offline. Use for login, password change/reset, OTP, and similar auth-adjacent
+   * flows.
+   */
+  public boolean isRateLimitedFailClosed(String key, int maxAttempts) {
+    try {
+      String value = redisTemplate.opsForValue().get(key);
+      if (value == null) {
+        return false;
+      }
+      return Integer.parseInt(value) >= maxAttempts;
+    } catch (Exception e) {
+      log.error("Redis unavailable for auth rate limit check, denying request: {}", e.getMessage());
+      return true;
     }
   }
 

--- a/src/main/java/com/kirjaswappi/backend/common/service/RateLimiterService.java
+++ b/src/main/java/com/kirjaswappi/backend/common/service/RateLimiterService.java
@@ -59,9 +59,10 @@ public class RateLimiterService {
 
   public void recordAttempt(String key, Duration window) {
     try {
-      redisTemplate.opsForValue().increment(key);
-      // Always set expiry to ensure TTL is present even if a prior set failed
-      redisTemplate.expire(key, window);
+      Long count = redisTemplate.opsForValue().increment(key);
+      if (count != null && count == 1L) {
+        redisTemplate.expire(key, window);
+      }
     } catch (Exception e) {
       log.warn("Redis unavailable for recording rate limit attempt: {}", e.getMessage());
     }

--- a/src/main/java/com/kirjaswappi/backend/common/utils/JwtUtil.java
+++ b/src/main/java/com/kirjaswappi/backend/common/utils/JwtUtil.java
@@ -218,7 +218,8 @@ public class JwtUtil {
 
   private boolean isRefreshTokenRevoked(String token) {
     if (redisTemplate == null) {
-      return false;
+      logger.warn("Redis unavailable — treating refresh token as revoked (fail-closed)");
+      return true;
     }
     try {
       String jti = extractAllClaims(token).getId();
@@ -227,7 +228,8 @@ public class JwtUtil {
       }
       return Boolean.TRUE.equals(redisTemplate.hasKey(REFRESH_TOKEN_REVOKED_PREFIX + jti));
     } catch (Exception e) {
-      return false;
+      logger.warn("Redis error during revocation check — failing closed: {}", e.getMessage());
+      return true;
     }
   }
 
@@ -276,13 +278,45 @@ public class JwtUtil {
         .compact();
   }
 
+  /**
+   * Atomically validate AND consume the password-reset token. Returns true only
+   * if the token is structurally valid, unexpired, and its jti has not been
+   * consumed yet (SETNX guarantees at-most-once use).
+   */
+  public boolean validateAndConsumePasswordResetToken(String token) {
+    try {
+      Claims claims = extractAllClaims(token);
+      if (!RESET_TOKEN_PURPOSE.equals(claims.get(TOKEN_PURPOSE)) || !isTokenValid(token)) {
+        return false;
+      }
+      if (redisTemplate == null) {
+        return true;
+      }
+      String jti = claims.getId();
+      if (jti == null || jti.isBlank()) {
+        return false;
+      }
+      Date exp = claims.getExpiration();
+      Duration ttl = exp != null
+          ? Duration.between(Instant.now(), exp.toInstant()).plusMinutes(1)
+          : Duration.ofMinutes(20);
+      if (ttl.isNegative() || ttl.isZero()) {
+        ttl = Duration.ofMinutes(1);
+      }
+      Boolean wasAbsent = redisTemplate.opsForValue()
+          .setIfAbsent(RESET_TOKEN_USED_PREFIX + jti, "1", ttl);
+      return Boolean.TRUE.equals(wasAbsent);
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
   public boolean validatePasswordResetToken(String token) {
     try {
       Claims claims = extractAllClaims(token);
       if (!RESET_TOKEN_PURPOSE.equals(claims.get(TOKEN_PURPOSE)) || !isTokenValid(token)) {
         return false;
       }
-      // Reject if jti is already in the consumed set.
       if (redisTemplate != null) {
         String jti = claims.getId();
         if (jti != null && Boolean.TRUE.equals(redisTemplate.hasKey(RESET_TOKEN_USED_PREFIX + jti))) {

--- a/src/main/java/com/kirjaswappi/backend/common/utils/JwtUtil.java
+++ b/src/main/java/com/kirjaswappi/backend/common/utils/JwtUtil.java
@@ -7,9 +7,12 @@ package com.kirjaswappi.backend.common.utils;
 import static com.kirjaswappi.backend.common.utils.Constants.ROLE;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Function;
 
 import javax.crypto.SecretKey;
@@ -21,13 +24,19 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 import com.kirjaswappi.backend.common.service.entities.AdminUser;
 
 @Component
 public class JwtUtil {
+  private static final Logger logger = LoggerFactory.getLogger(JwtUtil.class);
+
   @Value("${jwt.secret}")
   private String SECRET_STRING;
   @Value("${jwt.expiration}")
@@ -35,7 +44,13 @@ public class JwtUtil {
   @Value("${jwt.refresh-expiration:604800000}")
   private long REFRESH_TOKEN_EXPIRATION_MS; // default 7 days
 
+  @Autowired(required = false)
+  private StringRedisTemplate redisTemplate;
+
   private SecretKey SECRET_KEY;
+
+  private static final String RESET_TOKEN_USED_PREFIX = "jwt:reset:used:";
+  private static final String REFRESH_TOKEN_REVOKED_PREFIX = "jwt:refresh:revoked:";
 
   @PostConstruct
   public void init() {
@@ -166,11 +181,54 @@ public class JwtUtil {
     claims.put(EMAIL_CLAIM, email);
     return Jwts.builder()
         .claims(claims)
+        .id(UUID.randomUUID().toString())
         .subject(userId)
         .issuedAt(new Date(System.currentTimeMillis()))
         .expiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRATION_MS))
         .signWith(SECRET_KEY)
         .compact();
+  }
+
+  /**
+   * Adds the refresh token's jti to a Redis denylist so it cannot be used to mint
+   * new access tokens. Used on logout and password change.
+   */
+  public void revokeUserRefreshToken(String token) {
+    if (redisTemplate == null) {
+      return;
+    }
+    try {
+      Claims claims = extractAllClaims(token);
+      String jti = claims.getId();
+      if (jti == null || jti.isBlank()) {
+        return;
+      }
+      Date exp = claims.getExpiration();
+      Duration ttl = exp != null
+          ? Duration.between(Instant.now(), exp.toInstant()).plusMinutes(1)
+          : Duration.ofDays(7).plusMinutes(1);
+      if (ttl.isNegative() || ttl.isZero()) {
+        ttl = Duration.ofMinutes(1);
+      }
+      redisTemplate.opsForValue().set(REFRESH_TOKEN_REVOKED_PREFIX + jti, "1", ttl);
+    } catch (Exception e) {
+      logger.warn("Failed to revoke refresh token: {}", e.getMessage());
+    }
+  }
+
+  private boolean isRefreshTokenRevoked(String token) {
+    if (redisTemplate == null) {
+      return false;
+    }
+    try {
+      String jti = extractAllClaims(token).getId();
+      if (jti == null || jti.isBlank()) {
+        return false;
+      }
+      return Boolean.TRUE.equals(redisTemplate.hasKey(REFRESH_TOKEN_REVOKED_PREFIX + jti));
+    } catch (Exception e) {
+      return false;
+    }
   }
 
   public boolean isUserToken(String token) {
@@ -190,7 +248,10 @@ public class JwtUtil {
     if (!isUserToken(token) || !isTokenValid(token))
       return false;
     Claims claims = extractAllClaims(token);
-    return REFRESH_PURPOSE.equals(claims.get(TOKEN_PURPOSE));
+    if (!REFRESH_PURPOSE.equals(claims.get(TOKEN_PURPOSE))) {
+      return false;
+    }
+    return !isRefreshTokenRevoked(token);
   }
 
   public String extractUserId(String token) {
@@ -207,6 +268,7 @@ public class JwtUtil {
     claims.put(TOKEN_PURPOSE, RESET_TOKEN_PURPOSE);
     return Jwts.builder()
         .claims(claims)
+        .id(UUID.randomUUID().toString())
         .subject(email)
         .issuedAt(new Date(System.currentTimeMillis()))
         .expiration(new Date(System.currentTimeMillis() + RESET_TOKEN_EXPIRATION_MS))
@@ -217,9 +279,46 @@ public class JwtUtil {
   public boolean validatePasswordResetToken(String token) {
     try {
       Claims claims = extractAllClaims(token);
-      return RESET_TOKEN_PURPOSE.equals(claims.get(TOKEN_PURPOSE)) && isTokenValid(token);
+      if (!RESET_TOKEN_PURPOSE.equals(claims.get(TOKEN_PURPOSE)) || !isTokenValid(token)) {
+        return false;
+      }
+      // Reject if jti is already in the consumed set.
+      if (redisTemplate != null) {
+        String jti = claims.getId();
+        if (jti != null && Boolean.TRUE.equals(redisTemplate.hasKey(RESET_TOKEN_USED_PREFIX + jti))) {
+          return false;
+        }
+      }
+      return true;
     } catch (Exception e) {
       return false;
+    }
+  }
+
+  /**
+   * Mark the reset token's jti as consumed so it cannot be replayed within its
+   * expiry window. Stores until the JWT exp + a small buffer.
+   */
+  public void consumePasswordResetToken(String token) {
+    if (redisTemplate == null) {
+      return; // best-effort when Redis is unavailable
+    }
+    try {
+      Claims claims = extractAllClaims(token);
+      String jti = claims.getId();
+      if (jti == null || jti.isBlank()) {
+        return;
+      }
+      Date exp = claims.getExpiration();
+      Duration ttl = exp != null
+          ? Duration.between(Instant.now(), exp.toInstant()).plusMinutes(1)
+          : Duration.ofMinutes(20);
+      if (ttl.isNegative() || ttl.isZero()) {
+        ttl = Duration.ofMinutes(1);
+      }
+      redisTemplate.opsForValue().set(RESET_TOKEN_USED_PREFIX + jti, "1", ttl);
+    } catch (Exception e) {
+      logger.warn("Failed to mark reset token as consumed: {}", e.getMessage());
     }
   }
 

--- a/src/main/java/com/kirjaswappi/backend/common/utils/JwtUtil.java
+++ b/src/main/java/com/kirjaswappi/backend/common/utils/JwtUtil.java
@@ -141,6 +141,7 @@ public class JwtUtil {
   private String createRefreshToken(Map<String, Object> claims, String subject) {
     return Jwts.builder()
         .claims(claims)
+        .id(UUID.randomUUID().toString())
         .subject(subject)
         .issuedAt(new Date(System.currentTimeMillis()))
         .expiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRATION_MS))
@@ -195,6 +196,7 @@ public class JwtUtil {
    */
   public void revokeUserRefreshToken(String token) {
     if (redisTemplate == null) {
+      logger.error("Cannot revoke refresh token — Redis unavailable");
       return;
     }
     try {
@@ -224,7 +226,7 @@ public class JwtUtil {
     try {
       String jti = extractAllClaims(token).getId();
       if (jti == null || jti.isBlank()) {
-        return false;
+        return true;
       }
       return Boolean.TRUE.equals(redisTemplate.hasKey(REFRESH_TOKEN_REVOKED_PREFIX + jti));
     } catch (Exception e) {
@@ -290,7 +292,8 @@ public class JwtUtil {
         return false;
       }
       if (redisTemplate == null) {
-        return true;
+        logger.error("Cannot validate reset token — Redis unavailable (fail-closed)");
+        return false;
       }
       String jti = claims.getId();
       if (jti == null || jti.isBlank()) {

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/BookController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/BookController.java
@@ -142,9 +142,6 @@ public class BookController {
     if (filter.getNorth() < filter.getSouth()) {
       throw new BadRequestException("invalidMapBounds", "north must be >= south");
     }
-    if (filter.getEast() < filter.getWest()) {
-      throw new BadRequestException("invalidMapBounds", "east must be >= west");
-    }
     Page<Book> books = bookService.getAllBooksByFilter(filter, pageable);
     Page<BookListResponse> response = books.map(BookListResponse::new);
     return ResponseEntity.status(HttpStatus.OK).body(LinkBuilder.forPage(response, API_BASE + BOOKS + "/map"));

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/BookController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/BookController.java
@@ -63,9 +63,14 @@ public class BookController {
 
   @PostMapping(consumes = "multipart/form-data")
   @Operation(summary = "Add book to a user.", responses = {
-      @ApiResponse(responseCode = "201", description = "Book created.") })
-  public ResponseEntity<BookResponse> createBook(@Valid @ModelAttribute CreateBookRequest book) {
-    Book entity = book.toEntity();
+      @ApiResponse(responseCode = "201", description = "Book created."),
+      @ApiResponse(responseCode = "401", description = "Unauthenticated.") })
+  public ResponseEntity<BookResponse> createBook(@Valid @ModelAttribute CreateBookRequest book,
+      java.security.Principal principal) {
+    if (principal == null || principal.getName() == null) {
+      throw new AccessDeniedException("notAuthenticated", "");
+    }
+    Book entity = book.toEntity(principal.getName());
     entity = this.parseBookSwapCondition(book.getSwapCondition(), entity);
     entity = this.parseBookLocation(book.getLocation(), entity);
     Book savedBook = bookService.createBook(entity);

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/UserController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/UserController.java
@@ -323,7 +323,11 @@ public class UserController {
   public ResponseEntity<Void> logout(@Valid @RequestBody RefreshTokenRequest request) {
     String refreshToken = request.getUserRefreshToken();
     if (refreshToken != null && !refreshToken.isBlank()) {
-      jwtUtil.revokeUserRefreshToken(refreshToken);
+      var authentication = SecurityContextHolder.getContext().getAuthentication();
+      String tokenSubject = jwtUtil.extractUserId(refreshToken);
+      if (authentication != null && authentication.getName().equals(tokenSubject)) {
+        jwtUtil.revokeUserRefreshToken(refreshToken);
+      }
     }
     return ResponseEntity.noContent().build();
   }

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/UserController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/UserController.java
@@ -81,6 +81,22 @@ public class UserController {
   private static final Duration LOGIN_RATE_LIMIT_WINDOW = Duration.ofMinutes(15);
   private static final String LOGIN_RATE_LIMIT_PREFIX = "ratelimit:login:";
 
+  private static final int MAX_CHANGE_PW_ATTEMPTS = 5;
+  private static final Duration CHANGE_PW_RATE_LIMIT_WINDOW = Duration.ofMinutes(15);
+  private static final String CHANGE_PW_RATE_LIMIT_PREFIX = "ratelimit:change-password:";
+
+  private static final int MAX_RESET_PW_ATTEMPTS = 5;
+  private static final Duration RESET_PW_RATE_LIMIT_WINDOW = Duration.ofMinutes(15);
+  private static final String RESET_PW_RATE_LIMIT_PREFIX = "ratelimit:reset-password:";
+
+  private static final int MAX_REFRESH_TOKEN_ATTEMPTS = 30;
+  private static final Duration REFRESH_TOKEN_RATE_LIMIT_WINDOW = Duration.ofMinutes(15);
+  private static final String REFRESH_TOKEN_RATE_LIMIT_PREFIX = "ratelimit:refresh-token:";
+
+  private static final int MAX_GOOGLE_LOGIN_ATTEMPTS = 20;
+  private static final Duration GOOGLE_LOGIN_RATE_LIMIT_WINDOW = Duration.ofMinutes(15);
+  private static final String GOOGLE_LOGIN_RATE_LIMIT_PREFIX = "ratelimit:google-login:";
+
   @PostMapping(SIGNUP)
   @Operation(summary = "Create user.", responses = {
       @ApiResponse(responseCode = "201", description = "User created.") })
@@ -138,17 +154,24 @@ public class UserController {
   }
 
   @GetMapping(ID)
-  @Operation(summary = "Find user by User ID.", responses = {
+  @Operation(summary = "Find user by User ID.", description = "Returns the full profile when the authenticated user requests their own record; returns a minimal public profile otherwise.", responses = {
       @ApiResponse(responseCode = "200", description = "User found."),
+      @ApiResponse(responseCode = "401", description = "Unauthenticated."),
       @ApiResponse(responseCode = "404", description = "User not found.") })
-  public ResponseEntity<UserResponse> getUser(@Parameter(description = "User ID.") @PathVariable String id) {
+  public ResponseEntity<?> getUser(@Parameter(description = "User ID.") @PathVariable String id) {
     User user = userService.getUser(id);
-    return ResponseEntity.status(HttpStatus.OK).body(new UserResponse(user));
+    var authentication = SecurityContextHolder.getContext().getAuthentication();
+    String authenticatedUserId = authentication != null ? authentication.getName() : null;
+    if (authenticatedUserId != null && authenticatedUserId.equals(id)) {
+      return ResponseEntity.ok(new UserResponse(user));
+    }
+    return ResponseEntity.ok(new PublicUserResponse(user));
   }
 
   @GetMapping
-  @Operation(summary = "Find all users.", responses = {
-      @ApiResponse(responseCode = "200", description = "List of users.") })
+  @Operation(summary = "Find all users (admin).", responses = {
+      @ApiResponse(responseCode = "200", description = "List of users."),
+      @ApiResponse(responseCode = "403", description = "Not an admin.") })
   public ResponseEntity<List<UserResponse>> getUsers() {
     List<User> users = userService.getUsers();
     return ResponseEntity.status(HttpStatus.OK).body(users.stream().map(UserResponse::new).toList());
@@ -171,7 +194,8 @@ public class UserController {
   public ResponseEntity<UserLoginResponse> login(@Valid @RequestBody AuthenticateUserRequest authenticateUserRequest) {
     String email = authenticateUserRequest.getEmail();
     String rateLimitKey = email != null ? LOGIN_RATE_LIMIT_PREFIX + email.toLowerCase() : null;
-    if (rateLimitKey != null && rateLimiterService.isRateLimited(rateLimitKey, MAX_LOGIN_ATTEMPTS)) {
+    if (rateLimitKey != null
+        && rateLimiterService.isRateLimitedFailClosed(rateLimitKey, MAX_LOGIN_ATTEMPTS)) {
       throw new BadRequestException("tooManyLoginAttempts", email);
     }
     try {
@@ -194,11 +218,17 @@ public class UserController {
   @Operation(summary = "Login with Google.", responses = {
       @ApiResponse(responseCode = "200", description = "User logged in with Google."),
       @ApiResponse(responseCode = "401", description = "Invalid token.") })
-  public ResponseEntity<?> loginWithGoogle(@RequestBody LoginWithGoogleRequest request) {
+  public ResponseEntity<?> loginWithGoogle(@RequestBody LoginWithGoogleRequest request,
+      jakarta.servlet.http.HttpServletRequest httpRequest) {
+    String rateLimitKey = GOOGLE_LOGIN_RATE_LIMIT_PREFIX + httpRequest.getRemoteAddr();
+    if (rateLimiterService.isRateLimitedFailClosed(rateLimitKey, MAX_GOOGLE_LOGIN_ATTEMPTS)) {
+      throw new BadRequestException("tooManyLoginAttempts", "");
+    }
     GoogleIdToken idToken;
     try {
       idToken = googleIdTokenVerifier.verify(request.idToken());
     } catch (Exception e) {
+      rateLimiterService.recordAttempt(rateLimitKey, GOOGLE_LOGIN_RATE_LIMIT_WINDOW);
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
           .body(new ErrorResponse(new ErrorResponse.Error("invalidGoogleToken", "Invalid Google token")));
     }
@@ -213,21 +243,42 @@ public class UserController {
       User user = userService.findOrCreateGoogleUser(email, firstName, lastName, googleSub);
       String userToken = jwtUtil.generateUserToken(user.id(), user.email());
       String userRefreshToken = jwtUtil.generateUserRefreshToken(user.id(), user.email());
+      rateLimiterService.clearAttempts(rateLimitKey);
       return ResponseEntity.status(HttpStatus.OK).body(new UserLoginResponse(user, userToken, userRefreshToken));
     }
+    rateLimiterService.recordAttempt(rateLimitKey, GOOGLE_LOGIN_RATE_LIMIT_WINDOW);
     return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
         .body(new ErrorResponse(new ErrorResponse.Error("invalidIdToken", "Invalid ID token")));
   }
 
   @PostMapping(CHANGE_PASSWORD + EMAIL)
   @Operation(summary = "Change password.", responses = {
-      @ApiResponse(responseCode = "200", description = "Password changed.") })
+      @ApiResponse(responseCode = "200", description = "Password changed."),
+      @ApiResponse(responseCode = "403", description = "Path email does not match authenticated user.") })
   public ResponseEntity<ChangePasswordResponse> changePassword(
       @Parameter(description = "User email.") @PathVariable String email,
       @Valid @RequestBody ChangePasswordRequest request) {
-    userService.verifyCurrentPassword(request.toVerifyPasswordEntity(email));
-    String userEmail = userService.changePassword(request.toChangePasswordEntity(email));
-    return ResponseEntity.status(HttpStatus.OK).body(new ChangePasswordResponse(userEmail));
+    var authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication == null || authentication.getName() == null) {
+      throw new AccessDeniedException("notAccountOwner", email);
+    }
+    User authenticated = userService.getUser(authentication.getName());
+    if (!email.equalsIgnoreCase(authenticated.email())) {
+      throw new AccessDeniedException("notAccountOwner", email);
+    }
+    String rateLimitKey = CHANGE_PW_RATE_LIMIT_PREFIX + email.toLowerCase();
+    if (rateLimiterService.isRateLimitedFailClosed(rateLimitKey, MAX_CHANGE_PW_ATTEMPTS)) {
+      throw new BadRequestException("tooManyChangePasswordAttempts", email);
+    }
+    try {
+      userService.verifyCurrentPassword(request.toVerifyPasswordEntity(email));
+      String userEmail = userService.changePassword(request.toChangePasswordEntity(email));
+      rateLimiterService.clearAttempts(rateLimitKey);
+      return ResponseEntity.status(HttpStatus.OK).body(new ChangePasswordResponse(userEmail));
+    } catch (Exception e) {
+      rateLimiterService.recordAttempt(rateLimitKey, CHANGE_PW_RATE_LIMIT_WINDOW);
+      throw e;
+    }
   }
 
   @PostMapping(RESET_PASSWORD + EMAIL)
@@ -237,36 +288,77 @@ public class UserController {
   public ResponseEntity<ResetPasswordResponse> resetPassword(
       @Parameter(description = "User email.") @PathVariable String email,
       @Valid @RequestBody ResetPasswordRequest request) {
-    // Validate reset token from OTP verification
-    if (!jwtUtil.validatePasswordResetToken(request.getResetToken())) {
-      throw new BadRequestException("invalidOrExpiredResetToken", email);
+    String rateLimitKey = RESET_PW_RATE_LIMIT_PREFIX + email.toLowerCase();
+    if (rateLimiterService.isRateLimitedFailClosed(rateLimitKey, MAX_RESET_PW_ATTEMPTS)) {
+      throw new BadRequestException("tooManyResetPasswordAttempts", email);
     }
-    String tokenEmail = jwtUtil.extractEmailFromResetToken(request.getResetToken());
-    if (!email.equalsIgnoreCase(tokenEmail)) {
-      throw new BadRequestException("resetTokenEmailMismatch", email);
+    try {
+      // Validate reset token from OTP verification
+      if (!jwtUtil.validatePasswordResetToken(request.getResetToken())) {
+        rateLimiterService.recordAttempt(rateLimitKey, RESET_PW_RATE_LIMIT_WINDOW);
+        throw new BadRequestException("invalidOrExpiredResetToken", email);
+      }
+      String tokenEmail = jwtUtil.extractEmailFromResetToken(request.getResetToken());
+      if (!email.equalsIgnoreCase(tokenEmail)) {
+        rateLimiterService.recordAttempt(rateLimitKey, RESET_PW_RATE_LIMIT_WINDOW);
+        throw new BadRequestException("resetTokenEmailMismatch", email);
+      }
+      // Single-use: invalidate this token by marking its jti as consumed.
+      jwtUtil.consumePasswordResetToken(request.getResetToken());
+      String userEmail = userService.changePassword(request.toUserEntity(email));
+      rateLimiterService.clearAttempts(rateLimitKey);
+      return ResponseEntity.status(HttpStatus.OK).body(new ResetPasswordResponse(userEmail));
+    } catch (BadRequestException e) {
+      throw e;
+    } catch (Exception e) {
+      rateLimiterService.recordAttempt(rateLimitKey, RESET_PW_RATE_LIMIT_WINDOW);
+      throw e;
     }
-    String userEmail = userService.changePassword(request.toUserEntity(email));
-    return ResponseEntity.status(HttpStatus.OK).body(new ResetPasswordResponse(userEmail));
+  }
+
+  @PostMapping("/logout")
+  @Operation(summary = "Log out the current user.", description = "Revokes the supplied refresh token so it cannot be used again. Access tokens expire naturally within minutes.", responses = {
+      @ApiResponse(responseCode = "204", description = "Logged out.") })
+  public ResponseEntity<Void> logout(@Valid @RequestBody RefreshTokenRequest request) {
+    String refreshToken = request.getUserRefreshToken();
+    if (refreshToken != null && !refreshToken.isBlank()) {
+      jwtUtil.revokeUserRefreshToken(refreshToken);
+    }
+    return ResponseEntity.noContent().build();
   }
 
   @PostMapping("/refresh-token")
-  @Operation(summary = "Refresh user token.", responses = {
+  @Operation(summary = "Refresh user token.", description = "Returns a fresh access token AND a rotated refresh token; the previous refresh token is revoked.", responses = {
       @ApiResponse(responseCode = "200", description = "Token refreshed."),
       @ApiResponse(responseCode = "401", description = "Invalid or expired refresh token."),
       @ApiResponse(responseCode = "404", description = "User not found.") })
-  public ResponseEntity<?> refreshUserToken(@Valid @RequestBody RefreshTokenRequest request) {
+  public ResponseEntity<?> refreshUserToken(@Valid @RequestBody RefreshTokenRequest request,
+      jakarta.servlet.http.HttpServletRequest httpRequest) {
+    String rateLimitKey = REFRESH_TOKEN_RATE_LIMIT_PREFIX + httpRequest.getRemoteAddr();
+    if (rateLimiterService.isRateLimitedFailClosed(rateLimitKey, MAX_REFRESH_TOKEN_ATTEMPTS)) {
+      return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body("Too many refresh attempts");
+    }
     String refreshToken = request.getUserRefreshToken();
     try {
       if (!jwtUtil.validateUserRefreshToken(refreshToken)) {
+        rateLimiterService.recordAttempt(rateLimitKey, REFRESH_TOKEN_RATE_LIMIT_WINDOW);
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid or expired refresh token");
       }
     } catch (Exception e) {
+      rateLimiterService.recordAttempt(rateLimitKey, REFRESH_TOKEN_RATE_LIMIT_WINDOW);
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid or expired refresh token");
     }
     String userId = jwtUtil.extractUserId(refreshToken);
     User user = userService.getUser(userId);
-    String newToken = jwtUtil.generateUserToken(user.id(), user.email());
-    return ResponseEntity.ok(Map.of("userToken", newToken));
+    // Rotation: issue a new refresh token AND revoke the one we just consumed.
+    // If a stolen-token attacker tries to reuse the old refresh token they will
+    // be denied by the revocation check, even before its 7-day expiry.
+    String newAccessToken = jwtUtil.generateUserToken(user.id(), user.email());
+    String newRefreshToken = jwtUtil.generateUserRefreshToken(user.id(), user.email());
+    jwtUtil.revokeUserRefreshToken(refreshToken);
+    return ResponseEntity.ok(Map.of(
+        "userToken", newAccessToken,
+        "userRefreshToken", newRefreshToken));
   }
 
   @GetMapping(ID + BOOKS)

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/UserController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/UserController.java
@@ -273,6 +273,9 @@ public class UserController {
     try {
       userService.verifyCurrentPassword(request.toVerifyPasswordEntity(email));
       String userEmail = userService.changePassword(request.toChangePasswordEntity(email));
+      if (request.getUserRefreshToken() != null && !request.getUserRefreshToken().isBlank()) {
+        jwtUtil.revokeUserRefreshToken(request.getUserRefreshToken());
+      }
       rateLimiterService.clearAttempts(rateLimitKey);
       return ResponseEntity.status(HttpStatus.OK).body(new ChangePasswordResponse(userEmail));
     } catch (Exception e) {
@@ -293,8 +296,8 @@ public class UserController {
       throw new BadRequestException("tooManyResetPasswordAttempts", email);
     }
     try {
-      // Validate reset token from OTP verification
-      if (!jwtUtil.validatePasswordResetToken(request.getResetToken())) {
+      // Atomically validate + consume — prevents TOCTOU replay
+      if (!jwtUtil.validateAndConsumePasswordResetToken(request.getResetToken())) {
         rateLimiterService.recordAttempt(rateLimitKey, RESET_PW_RATE_LIMIT_WINDOW);
         throw new BadRequestException("invalidOrExpiredResetToken", email);
       }
@@ -303,8 +306,6 @@ public class UserController {
         rateLimiterService.recordAttempt(rateLimitKey, RESET_PW_RATE_LIMIT_WINDOW);
         throw new BadRequestException("resetTokenEmailMismatch", email);
       }
-      // Single-use: invalidate this token by marking its jti as consumed.
-      jwtUtil.consumePasswordResetToken(request.getResetToken());
       String userEmail = userService.changePassword(request.toUserEntity(email));
       rateLimiterService.clearAttempts(rateLimitKey);
       return ResponseEntity.status(HttpStatus.OK).body(new ResetPasswordResponse(userEmail));

--- a/src/main/java/com/kirjaswappi/backend/http/dtos/requests/ChangePasswordRequest.java
+++ b/src/main/java/com/kirjaswappi/backend/http/dtos/requests/ChangePasswordRequest.java
@@ -26,6 +26,9 @@ public class ChangePasswordRequest {
   @Schema(description = "The confirm password of the user.", example = "newPassword", requiredMode = REQUIRED)
   private String confirmPassword;
 
+  @Schema(description = "Optional refresh token to revoke on password change.")
+  private String userRefreshToken;
+
   public User toChangePasswordEntity(String email) {
     this.validateProperties(email);
     return User.builder()

--- a/src/main/java/com/kirjaswappi/backend/http/dtos/requests/CreateBookRequest.java
+++ b/src/main/java/com/kirjaswappi/backend/http/dtos/requests/CreateBookRequest.java
@@ -109,7 +109,7 @@ public class CreateBookRequest {
     if (!ValidationUtil.validateNotBlank(this.swapCondition)) {
       throw new BadRequestException("swapConditionIsRequired");
     }
-    if (this.coverPhotos == null) {
+    if (this.coverPhotos == null || this.coverPhotos.isEmpty()) {
       throw new BadRequestException("atLeastOneCoverPhotoIsRequired");
     }
     for (var coverPhoto : this.coverPhotos) {

--- a/src/main/java/com/kirjaswappi/backend/http/dtos/requests/CreateBookRequest.java
+++ b/src/main/java/com/kirjaswappi/backend/http/dtos/requests/CreateBookRequest.java
@@ -46,9 +46,6 @@ public class CreateBookRequest {
   @Schema(description = "The cover photos of the book.", requiredMode = REQUIRED)
   private List<MultipartFile> coverPhotos;
 
-  @Schema(description = "The user ID of the book owner.", example = "123456", requiredMode = REQUIRED)
-  private String ownerId;
-
   @Schema(description = "Swap condition of the book in JSON format.", requiredMode = REQUIRED, example = """
       {
         "conditionType": "ByBooks",
@@ -77,9 +74,9 @@ public class CreateBookRequest {
       }""")
   private String location;
 
-  public Book toEntity() {
+  public Book toEntity(String ownerId) {
     this.validateProperties();
-    var user = new User().id(this.ownerId);
+    var user = new User().id(ownerId);
 
     return Book.builder()
         .title(this.title)
@@ -117,9 +114,6 @@ public class CreateBookRequest {
     }
     for (var coverPhoto : this.coverPhotos) {
       ValidationUtil.validateMediaType(coverPhoto);
-    }
-    if (!ValidationUtil.validateNotBlank(this.ownerId)) {
-      throw new BadRequestException("ownerIdCannotBeBlank", this.ownerId);
     }
   }
 }

--- a/src/main/java/com/kirjaswappi/backend/http/dtos/responses/PublicUserResponse.java
+++ b/src/main/java/com/kirjaswappi/backend/http/dtos/responses/PublicUserResponse.java
@@ -25,6 +25,7 @@ public class PublicUserResponse {
   private String city;
   private String country;
   private String aboutMe;
+  private String profilePhoto;
   private List<String> favGenres;
   private List<BookListResponse> books;
 
@@ -35,6 +36,7 @@ public class PublicUserResponse {
     this.city = entity.city();
     this.country = entity.country();
     this.aboutMe = entity.aboutMe();
+    this.profilePhoto = entity.profilePhoto();
     this.favGenres = entity.favGenres() != null ? entity.favGenres().stream().map(Genre::getName).toList()
         : List.of();
     this.books = entity.books() != null ? entity.books().stream().map(BookListResponse::new).toList()

--- a/src/main/java/com/kirjaswappi/backend/http/dtos/responses/PublicUserResponse.java
+++ b/src/main/java/com/kirjaswappi/backend/http/dtos/responses/PublicUserResponse.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 KirjaSwappi or KirjaSwappi affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+package com.kirjaswappi.backend.http.dtos.responses;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import com.kirjaswappi.backend.service.entities.Genre;
+import com.kirjaswappi.backend.service.entities.User;
+
+/**
+ * Minimal user profile fields safe to return to other authenticated users.
+ * Intentionally excludes email, address, phone, and favourite books.
+ */
+@Getter
+@Setter
+public class PublicUserResponse {
+  private String id;
+  private String firstName;
+  private String lastName;
+  private String city;
+  private String country;
+  private String aboutMe;
+  private List<String> favGenres;
+  private List<BookListResponse> books;
+
+  public PublicUserResponse(User entity) {
+    this.id = entity.id();
+    this.firstName = entity.firstName();
+    this.lastName = entity.lastName();
+    this.city = entity.city();
+    this.country = entity.country();
+    this.aboutMe = entity.aboutMe();
+    this.favGenres = entity.favGenres() != null ? entity.favGenres().stream().map(Genre::getName).toList()
+        : List.of();
+    this.books = entity.books() != null ? entity.books().stream().map(BookListResponse::new).toList()
+        : List.of();
+  }
+}

--- a/src/main/java/com/kirjaswappi/backend/http/validations/ValidationUtil.java
+++ b/src/main/java/com/kirjaswappi/backend/http/validations/ValidationUtil.java
@@ -32,6 +32,9 @@ public class ValidationUtil {
     if (password == null || password.trim().isEmpty()) {
       throw new BadRequestException(fieldName + "CannotBeBlank", fieldName);
     }
+    if (password.length() > 128) {
+      throw new BadRequestException("passwordTooLong", fieldName);
+    }
     if (password.length() < 8) {
       throw new BadRequestException("passwordTooShort", fieldName);
     }
@@ -115,7 +118,8 @@ public class ValidationUtil {
     }
     // HEIC/HEIF: "....ftypheic" / "....ftypmif1" / "....ftypmsf1"
     if (head.length >= 12 && head[4] == 'f' && head[5] == 't' && head[6] == 'y' && head[7] == 'p') {
-      return true;
+      String brand = new String(head, 8, 4, java.nio.charset.StandardCharsets.US_ASCII);
+      return brand.equals("heic") || brand.equals("heix") || brand.equals("mif1") || brand.equals("msf1");
     }
     return false;
   }

--- a/src/main/java/com/kirjaswappi/backend/http/validations/ValidationUtil.java
+++ b/src/main/java/com/kirjaswappi/backend/http/validations/ValidationUtil.java
@@ -4,6 +4,7 @@
  */
 package com.kirjaswappi.backend.http.validations;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -61,6 +62,62 @@ public class ValidationUtil {
         fileExtension == null || !Arrays.asList(allowedExtensions).contains(fileExtension.toLowerCase())) {
       throw new UnsupportedMediaTypeException(image);
     }
+
+    // Magic-byte sniffing. Client-supplied content type and filename can lie;
+    // verify the leading bytes match an image format we accept.
+    if (!hasImageMagicBytes(image)) {
+      throw new UnsupportedMediaTypeException(image);
+    }
+  }
+
+  /**
+   * Returns true if the first bytes of {@code image} match a known image format
+   * header (JPEG, PNG, GIF, BMP, WEBP, HEIC/HEIF).
+   */
+  private static boolean hasImageMagicBytes(MultipartFile image) {
+    if (image == null || image.isEmpty()) {
+      return false;
+    }
+    byte[] head;
+    try (var in = image.getInputStream()) {
+      head = in.readNBytes(16);
+    } catch (IOException e) {
+      return false;
+    }
+    if (head == null || head.length < 4) {
+      return false;
+    }
+
+    // JPEG: FF D8 FF
+    if ((head[0] & 0xFF) == 0xFF && (head[1] & 0xFF) == 0xD8 && (head[2] & 0xFF) == 0xFF) {
+      return true;
+    }
+    // PNG: 89 50 4E 47 0D 0A 1A 0A
+    if (head.length >= 8
+        && (head[0] & 0xFF) == 0x89 && head[1] == 'P' && head[2] == 'N' && head[3] == 'G'
+        && (head[4] & 0xFF) == 0x0D && (head[5] & 0xFF) == 0x0A
+        && (head[6] & 0xFF) == 0x1A && (head[7] & 0xFF) == 0x0A) {
+      return true;
+    }
+    // GIF: "GIF87a" or "GIF89a"
+    if (head.length >= 6 && head[0] == 'G' && head[1] == 'I' && head[2] == 'F'
+        && head[3] == '8' && (head[4] == '7' || head[4] == '9') && head[5] == 'a') {
+      return true;
+    }
+    // BMP: "BM"
+    if (head[0] == 'B' && head[1] == 'M') {
+      return true;
+    }
+    // WEBP: "RIFF" .... "WEBP"
+    if (head.length >= 12 && head[0] == 'R' && head[1] == 'I' && head[2] == 'F' && head[3] == 'F'
+        && head[8] == 'W' && head[9] == 'E' && head[10] == 'B' && head[11] == 'P') {
+      return true;
+    }
+    // HEIC/HEIF: "....ftypheic" / "....ftypmif1" / "....ftypmsf1"
+    if (head.length >= 12 && head[4] == 'f' && head[5] == 't' && head[6] == 'y' && head[7] == 'p') {
+      return true;
+    }
+    return false;
   }
 
   public static UUID validateUUID(String id) {

--- a/src/main/java/com/kirjaswappi/backend/jpa/daos/SwapRequestDao.java
+++ b/src/main/java/com/kirjaswappi/backend/jpa/daos/SwapRequestDao.java
@@ -12,6 +12,7 @@ import lombok.*;
 import lombok.experimental.Accessors;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Version;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.mapping.DBRef;
@@ -33,6 +34,9 @@ import com.mongodb.lang.Nullable;
 public class SwapRequestDao {
   @Id
   private String id;
+
+  @Version
+  private Long version;
 
   @NotNull
   @DBRef

--- a/src/main/java/com/kirjaswappi/backend/jpa/repositories/ChatMessageRepository.java
+++ b/src/main/java/com/kirjaswappi/backend/jpa/repositories/ChatMessageRepository.java
@@ -17,6 +17,10 @@ public interface ChatMessageRepository
     extends MongoRepository<ChatMessageDao, String>, CustomChatMessageRepository {
   List<ChatMessageDao> findBySwapRequestIdOrderBySentAtAsc(String swapRequestId);
 
+  // Spring Data Mongo stores DBRef sender.$id as ObjectId because the inserted
+  // user IDs are 24-char hex strings (verified by
+  // ChatMessageRepositoryIntegrationTest).
+  // Pass ObjectId so the type matches the stored value.
   @Query(value = "{ 'swapRequestId': ?0, 'readByReceiver': false, 'sender.$id': { $ne: ?1 } }", count = true)
   long countBySwapRequestIdAndReadByReceiverFalseAndSenderIdNot(String swapRequestId, ObjectId userId);
 

--- a/src/main/java/com/kirjaswappi/backend/jpa/repositories/CustomChatMessageRepositoryImpl.java
+++ b/src/main/java/com/kirjaswappi/backend/jpa/repositories/CustomChatMessageRepositoryImpl.java
@@ -24,6 +24,7 @@ public class CustomChatMessageRepositoryImpl implements CustomChatMessageReposit
 
   @Override
   public long markAsRead(String swapRequestId, String userId) {
+    // Spring Data Mongo stores DBRef sender.$id as ObjectId; match the type.
     Query query = new Query(Criteria.where("swapRequestId").is(swapRequestId)
         .and("readByReceiver").is(false)
         .and("sender.$id").ne(new ObjectId(userId)));

--- a/src/main/java/com/kirjaswappi/backend/jpa/repositories/SwapRequestRepository.java
+++ b/src/main/java/com/kirjaswappi/backend/jpa/repositories/SwapRequestRepository.java
@@ -6,6 +6,7 @@ package com.kirjaswappi.backend.jpa.repositories;
 
 import java.util.List;
 
+import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 
@@ -17,9 +18,9 @@ public interface SwapRequestRepository extends MongoRepository<SwapRequestDao, S
    * for this triple. Closed states (REJECTED/CANCELLED/EXPIRED/COMPLETED) must
    * not block the same pair from re-requesting the book later.
    */
-  @Query(value = "{ 'sender.id': ?0, 'receiver.id': ?1, 'bookToSwapWith.id': ?2, "
+  @Query(value = "{ 'sender.$id': ?0, 'receiver.$id': ?1, 'bookToSwapWith.$id': ?2, "
       + "'swapStatus': { $in: ['Pending', 'Accepted', 'Reserved'] } }", exists = true)
-  boolean existsAlready(String senderId, String receiverId, String bookToSwapWithId);
+  boolean existsAlready(ObjectId senderId, ObjectId receiverId, ObjectId bookToSwapWithId);
 
   // Inbox query methods for received swap requests
   List<SwapRequestDao> findByReceiverIdOrderByRequestedAtDesc(String receiverId);

--- a/src/main/java/com/kirjaswappi/backend/jpa/repositories/SwapRequestRepository.java
+++ b/src/main/java/com/kirjaswappi/backend/jpa/repositories/SwapRequestRepository.java
@@ -12,7 +12,13 @@ import org.springframework.data.mongodb.repository.Query;
 import com.kirjaswappi.backend.jpa.daos.SwapRequestDao;
 
 public interface SwapRequestRepository extends MongoRepository<SwapRequestDao, String> {
-  @Query(value = "{ 'sender.id': ?0, 'receiver.id': ?1, 'bookToSwapWith.id': ?2 }", exists = true)
+  /**
+   * Returns true only if there is an *active* swap (PENDING/ACCEPTED/RESERVED)
+   * for this triple. Closed states (REJECTED/CANCELLED/EXPIRED/COMPLETED) must
+   * not block the same pair from re-requesting the book later.
+   */
+  @Query(value = "{ 'sender.id': ?0, 'receiver.id': ?1, 'bookToSwapWith.id': ?2, "
+      + "'swapStatus': { $in: ['Pending', 'Accepted', 'Reserved'] } }", exists = true)
   boolean existsAlready(String senderId, String receiverId, String bookToSwapWithId);
 
   // Inbox query methods for received swap requests

--- a/src/main/java/com/kirjaswappi/backend/service/ChatService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/ChatService.java
@@ -15,6 +15,10 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -60,6 +64,8 @@ public class ChatService {
   private final ProfanityFilterService profanityFilterService;
 
   private final org.springframework.cache.CacheManager cacheManager;
+
+  private final MongoTemplate mongoTemplate;
 
   /**
    * Statuses in which back-and-forth chat is permitted. After REJECTED / EXPIRED
@@ -386,12 +392,16 @@ public class ChatService {
   }
 
   private void resetRecipientReadTimestamp(SwapRequestDao swapRequest, String recipientId) {
+    Update update = new Update();
     if (swapRequest.receiver().id().equals(recipientId)) {
-      swapRequest.readByReceiverAt(null);
+      update.set("readByReceiverAt", null);
     } else {
-      swapRequest.readBySenderAt(null);
+      update.set("readBySenderAt", null);
     }
-    swapRequestRepository.save(swapRequest);
+    mongoTemplate.updateFirst(
+        Query.query(Criteria.where("_id").is(swapRequest.id())),
+        update,
+        SwapRequestDao.class);
   }
 
   private List<String> convertImageIdsToUrls(List<String> imageIds) {

--- a/src/main/java/com/kirjaswappi/backend/service/ChatService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/ChatService.java
@@ -15,7 +15,6 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.bson.types.ObjectId;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,8 +26,10 @@ import com.kirjaswappi.backend.common.service.ImageService;
 import com.kirjaswappi.backend.common.service.ProfanityFilterService;
 import com.kirjaswappi.backend.jpa.daos.ChatMessageDao;
 import com.kirjaswappi.backend.jpa.daos.SwapRequestDao;
+import com.kirjaswappi.backend.jpa.daos.UserDao;
 import com.kirjaswappi.backend.jpa.repositories.ChatMessageRepository;
 import com.kirjaswappi.backend.jpa.repositories.SwapRequestRepository;
+import com.kirjaswappi.backend.jpa.repositories.UserRepository;
 import com.kirjaswappi.backend.mapper.ChatMessageMapper;
 import com.kirjaswappi.backend.mapper.SwapRequestMapper;
 import com.kirjaswappi.backend.service.entities.ChatMessage;
@@ -50,6 +51,8 @@ public class ChatService {
 
   private final UserService userService;
 
+  private final UserRepository userRepository;
+
   private final ImageService imageService;
 
   private final SimpMessagingTemplate messagingTemplate;
@@ -57,6 +60,16 @@ public class ChatService {
   private final ProfanityFilterService profanityFilterService;
 
   private final org.springframework.cache.CacheManager cacheManager;
+
+  /**
+   * Statuses in which back-and-forth chat is permitted. After REJECTED / EXPIRED
+   * / CANCELLED / COMPLETED, history is still readable but no new messages may be
+   * sent. We compare case-insensitively because some legacy documents store the
+   * upper-cased name ("PENDING") while the enum's canonical code is mixed-case
+   * ("Pending").
+   */
+  private static final java.util.Set<String> ACTIVE_CHAT_STATUSES = java.util.Set.of(
+      "PENDING", "ACCEPTED", "RESERVED");
 
   public List<ChatMessage> getChatMessages(String swapRequestId, String userId) {
 
@@ -99,6 +112,16 @@ public class ChatService {
 
     // Validate user has access to this chat (must be sender or receiver)
     if (!hasAccessToChat(swapRequest, senderId)) {
+      throw new ChatAccessDeniedException();
+    }
+
+    // Block sending after the swap is closed (history remains readable).
+    if (!isChatActive(swapRequest)) {
+      throw new BadRequestException("chatClosedForSwap", swapRequest.swapStatus());
+    }
+
+    // Block sending if the counterparty has blocked the sender.
+    if (isBlockedByCounterparty(swapRequest, senderId)) {
       throw new ChatAccessDeniedException();
     }
 
@@ -160,6 +183,14 @@ public class ChatService {
 
     // Validate user has access to this chat (must be sender or receiver)
     if (!hasAccessToChat(swapRequest, senderId)) {
+      throw new ChatAccessDeniedException();
+    }
+
+    if (!isChatActive(swapRequest)) {
+      throw new BadRequestException("chatClosedForSwap", swapRequest.swapStatus());
+    }
+
+    if (isBlockedByCounterparty(swapRequest, senderId)) {
       throw new ChatAccessDeniedException();
     }
 
@@ -263,7 +294,7 @@ public class ChatService {
 
     // Count unread messages not sent by the current user
     return chatMessageRepository.countBySwapRequestIdAndReadByReceiverFalseAndSenderIdNot(
-        swapRequestId, new ObjectId(userId));
+        swapRequestId, new org.bson.types.ObjectId(userId));
   }
 
   public void clearUnreadCountCache(String userId, String swapRequestId) {
@@ -297,7 +328,7 @@ public class ChatService {
       return Map.of();
     }
     List<ChatMessageDao> unreadMessages = chatMessageRepository
-        .findUnreadBySwapRequestIdInAndSenderIdNot(swapRequestIds, new ObjectId(userId));
+        .findUnreadBySwapRequestIdInAndSenderIdNot(swapRequestIds, new org.bson.types.ObjectId(userId));
     Map<String, Long> result = new HashMap<>();
     for (ChatMessageDao msg : unreadMessages) {
       result.merge(msg.swapRequestId(), 1L, Long::sum);
@@ -333,6 +364,25 @@ public class ChatService {
   private boolean hasAccessToChat(SwapRequestDao swapRequest, String userId) {
     return swapRequest.sender().id().equals(userId) ||
         swapRequest.receiver().id().equals(userId);
+  }
+
+  private boolean isChatActive(SwapRequestDao swapRequest) {
+    String status = swapRequest.swapStatus();
+    return status != null && ACTIVE_CHAT_STATUSES.contains(status.toUpperCase(java.util.Locale.ROOT));
+  }
+
+  /**
+   * Returns true if the *counterparty* of the sender has the sender on their
+   * block list. We never silently swallow the message — the API rejects it.
+   */
+  private boolean isBlockedByCounterparty(SwapRequestDao swapRequest, String senderId) {
+    String counterpartyId = swapRequest.sender().id().equals(senderId)
+        ? swapRequest.receiver().id()
+        : swapRequest.sender().id();
+    return userRepository.findById(counterpartyId)
+        .map(UserDao::blockedUserIds)
+        .filter(blocked -> blocked != null && blocked.contains(senderId))
+        .isPresent();
   }
 
   private void resetRecipientReadTimestamp(SwapRequestDao swapRequest, String recipientId) {

--- a/src/main/java/com/kirjaswappi/backend/service/SwapService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/SwapService.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 
+import org.bson.types.ObjectId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -50,8 +51,8 @@ public class SwapService {
 
   public SwapRequest createSwapRequest(SwapRequest swapRequest) {
     // validation: check if the swap request exists already for this book
-    if (swapRequestRepository.existsAlready(swapRequest.sender().id(),
-        swapRequest.receiver().id(), swapRequest.bookToSwapWith().id())) {
+    if (swapRequestRepository.existsAlready(new ObjectId(swapRequest.sender().id()),
+        new ObjectId(swapRequest.receiver().id()), new ObjectId(swapRequest.bookToSwapWith().id()))) {
       throw new SwapRequestExistsAlreadyException();
     }
 
@@ -215,13 +216,21 @@ public class SwapService {
       return swapRequest;
     }
     List<String> rawCovers = swapRequest.bookToSwapWith().coverPhotos();
-    if (rawCovers == null || rawCovers.isEmpty()) {
-      return swapRequest;
+    if (rawCovers != null && !rawCovers.isEmpty()) {
+      List<String> resolved = new ArrayList<>(rawCovers.size());
+      for (String uniqueId : rawCovers) {
+        resolved.add(photoService.getBookCoverPhoto(uniqueId));
+      }
+      swapRequest = swapRequest.withBookToSwapWith(swapRequest.bookToSwapWith().withCoverPhotos(resolved));
     }
-    List<String> resolved = new ArrayList<>(rawCovers.size());
-    for (String uniqueId : rawCovers) {
-      resolved.add(photoService.getBookCoverPhoto(uniqueId));
+
+    if (swapRequest.swapOffer() != null && swapRequest.swapOffer().offeredBook() != null) {
+      String offeredCover = swapRequest.swapOffer().offeredBook().getCoverPhoto();
+      if (offeredCover != null && !offeredCover.isBlank()) {
+        swapRequest.swapOffer().offeredBook().setCoverPhoto(photoService.getBookCoverPhoto(offeredCover));
+      }
     }
-    return swapRequest.withBookToSwapWith(swapRequest.bookToSwapWith().withCoverPhotos(resolved));
+
+    return swapRequest;
   }
 }

--- a/src/main/java/com/kirjaswappi/backend/service/SwapService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/SwapService.java
@@ -77,10 +77,7 @@ public class SwapService {
     Book bookToSwapWith = bookService.getBookById(swapRequest.bookToSwapWith().id());
 
     // check if the bookToSwapWith belongs to the receiver:
-    if (Optional.ofNullable(receiver.books())
-        .stream()
-        .flatMap(Collection::stream)
-        .noneMatch(book -> book.id().equals(bookToSwapWith.id()))) {
+    if (bookToSwapWith.owner() == null || !bookToSwapWith.owner().id().equals(receiver.id())) {
       throw new IllegalSwapRequestException("bookToSwapWithDoesNotBelongToReceiver");
     }
 

--- a/src/main/java/com/kirjaswappi/backend/service/SwapService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/SwapService.java
@@ -4,7 +4,9 @@
  */
 package com.kirjaswappi.backend.service;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
@@ -17,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.kirjaswappi.backend.common.service.NotificationClient;
 import com.kirjaswappi.backend.jpa.daos.SwapRequestDao;
 import com.kirjaswappi.backend.jpa.repositories.SwapRequestRepository;
+import com.kirjaswappi.backend.jpa.repositories.UserRepository;
 import com.kirjaswappi.backend.mapper.SwapRequestMapper;
 import com.kirjaswappi.backend.service.entities.*;
 import com.kirjaswappi.backend.service.enums.SwapStatus;
@@ -33,6 +36,8 @@ public class SwapService {
 
   private final UserService userService;
 
+  private final UserRepository userRepository;
+
   private final BookService bookService;
 
   private final GenreService genreService;
@@ -40,6 +45,8 @@ public class SwapService {
   private final SwapRequestRepository swapRequestRepository;
 
   private final NotificationClient notificationClient;
+
+  private final PhotoService photoService;
 
   public SwapRequest createSwapRequest(SwapRequest swapRequest) {
     // validation: check if the swap request exists already for this book
@@ -57,6 +64,15 @@ public class SwapService {
     User sender = userService.getUser(swapRequest.sender().id());
     // set receiver:
     User receiver = userService.getUser(swapRequest.receiver().id());
+
+    // validation: receiver has blocked the sender — refuse the request.
+    boolean blocked = userRepository.findById(receiver.id())
+        .map(dao -> dao.blockedUserIds())
+        .map(list -> list != null && list.contains(sender.id()))
+        .orElse(false);
+    if (blocked) {
+      throw new IllegalSwapRequestException("receiverHasBlockedSender");
+    }
     // set bookToSwapWith:
     Book bookToSwapWith = bookService.getBookById(swapRequest.bookToSwapWith().id());
 
@@ -124,7 +140,7 @@ public class SwapService {
           receiver.id(), bookToSwapWith.title(), e);
     }
 
-    return SwapRequestMapper.toEntity(createdDao);
+    return resolveCoverPhotoUrls(SwapRequestMapper.toEntity(createdDao));
   }
 
   // Used only by admin
@@ -166,25 +182,49 @@ public class SwapService {
       throw new InvalidStatusTransitionException(currentStatus.getCode(), newStatus.getCode());
     }
 
-    // Update the status
-    swapRequestDao = SwapRequestMapper.toDao(swapRequest.withSwapStatus(newStatus));
+    // Update the status (preserve @Version on the existing DAO so optimistic
+    // locking catches concurrent updates).
+    swapRequestDao.swapStatus(newStatus.getCode());
+    swapRequestDao.updatedAt(java.time.Instant.now());
     SwapRequestDao updatedDao = swapRequestRepository.save(swapRequestDao);
 
-    // Send notification to sender about status change
+    // Notify the *counterparty* (the user who did NOT initiate this transition).
+    // Receiver-only transitions (ACCEPTED/REJECTED/RESERVED) inform the sender;
+    // sender-only transitions (EXPIRED) and either-party transitions
+    // (COMPLETED/CANCELLED) inform the other participant.
+    String counterpartyId = isSender ? swapRequest.receiver().id() : swapRequest.sender().id();
     try {
       String notificationTitle = "Swap Request Update";
-      String notificationMessage = String.format("Your swap request for '%s' has been %s",
+      String notificationMessage = String.format("Swap request for '%s' has been %s",
           swapRequest.bookToSwapWith().title(),
           newStatus.getCode().toLowerCase());
 
-      notificationClient.sendNotification(swapRequest.sender().id(), notificationTitle, notificationMessage);
+      notificationClient.sendNotification(counterpartyId, notificationTitle, notificationMessage);
     } catch (Exception e) {
       // Log error but don't fail the status update
-      logger.error("Failed to send notification for swap request status update. Sender: {}, Status: {}",
-          swapRequest.sender().id(), newStatus.getCode(), e);
+      logger.error("Failed to send notification for swap request status update. Counterparty: {}, Status: {}",
+          counterpartyId, newStatus.getCode(), e);
     }
 
-    return SwapRequestMapper.toEntity(updatedDao);
+    return resolveCoverPhotoUrls(SwapRequestMapper.toEntity(updatedDao));
   }
 
+  /**
+   * Replace storage IDs on the embedded book's cover photos with presigned URLs.
+   * Without this, swap responses leak raw S3 keys to clients.
+   */
+  private SwapRequest resolveCoverPhotoUrls(SwapRequest swapRequest) {
+    if (swapRequest == null || swapRequest.bookToSwapWith() == null) {
+      return swapRequest;
+    }
+    List<String> rawCovers = swapRequest.bookToSwapWith().coverPhotos();
+    if (rawCovers == null || rawCovers.isEmpty()) {
+      return swapRequest;
+    }
+    List<String> resolved = new ArrayList<>(rawCovers.size());
+    for (String uniqueId : rawCovers) {
+      resolved.add(photoService.getBookCoverPhoto(uniqueId));
+    }
+    return swapRequest.withBookToSwapWith(swapRequest.bookToSwapWith().withCoverPhotos(resolved));
+  }
 }

--- a/src/main/java/com/kirjaswappi/backend/service/filters/FindAllBooksFilter.java
+++ b/src/main/java/com/kirjaswappi/backend/service/filters/FindAllBooksFilter.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 
-import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.core.query.Criteria;
 
 @Getter
@@ -87,14 +86,14 @@ public class FindAllBooksFilter {
     // Add filter criteria:
     combinedCriteria.add(Criteria.where("isDeleted").is(false));
 
-    // Filter by owner ID if provided:
+    // DBRef owner.$id is stored as ObjectId by Spring Data Mongo (verified by
+    // UserApiIntegrationTest pagination assertions). Match the type.
     if (this.ownerId != null && !this.ownerId.isEmpty()) {
-      combinedCriteria.add(Criteria.where("owner.$id").is(new ObjectId(this.ownerId)));
+      combinedCriteria.add(Criteria.where("owner.$id").is(new org.bson.types.ObjectId(this.ownerId)));
     }
 
-    // Filter by not owner ID if provided:
     if (this.notOwnerId != null && !this.notOwnerId.isEmpty()) {
-      combinedCriteria.add(Criteria.where("owner.$id").ne(new ObjectId(this.notOwnerId)));
+      combinedCriteria.add(Criteria.where("owner.$id").ne(new org.bson.types.ObjectId(this.notOwnerId)));
     }
 
     // Add language, condition, and genre filters:

--- a/src/main/java/com/kirjaswappi/backend/service/filters/FindAllBooksFilter.java
+++ b/src/main/java/com/kirjaswappi/backend/service/filters/FindAllBooksFilter.java
@@ -77,10 +77,11 @@ public class FindAllBooksFilter {
 
     // Add search criteria:
     if (search != null && !search.isEmpty()) {
+      String escaped = java.util.regex.Pattern.quote(search);
       combinedCriteria.add(new Criteria().orOperator(
-          Criteria.where("title").regex(search, "i"),
-          Criteria.where("author").regex(search, "i"),
-          Criteria.where("description").regex(search, "i")));
+          Criteria.where("title").regex(escaped, "i"),
+          Criteria.where("author").regex(escaped, "i"),
+          Criteria.where("description").regex(escaped, "i")));
     }
 
     // Add filter criteria:
@@ -166,12 +167,12 @@ public class FindAllBooksFilter {
 
     // Filter by city if provided:
     if (city != null && !city.isEmpty()) {
-      combinedCriteria.add(Criteria.where("location.city").regex(city, "i"));
+      combinedCriteria.add(Criteria.where("location.city").regex(java.util.regex.Pattern.quote(city), "i"));
     }
 
     // Filter by country if provided:
     if (country != null && !country.isEmpty()) {
-      combinedCriteria.add(Criteria.where("location.country").regex(country, "i"));
+      combinedCriteria.add(Criteria.where("location.country").regex(java.util.regex.Pattern.quote(country), "i"));
     }
 
     // Filter by map bounding box if provided:

--- a/src/main/resources/application-cloud.yaml
+++ b/src/main/resources/application-cloud.yaml
@@ -7,6 +7,8 @@ spring:
       autoIndexCreation: true
       uri: ${MONGODB_URI}
       database: ${MONGODB_DATABASE}
+    redis:
+      password: ${REDIS_PASSWORD}
   cache:
     type: redis
   threads:
@@ -14,6 +16,9 @@ spring:
       enabled: true
   lifecycle:
     timeout-per-shutdown-phase: 30s
+  rabbitmq:
+    username: ${RABBITMQ_USERNAME}
+    password: ${RABBITMQ_PASSWORD}
 
 springdoc:
   api-docs:

--- a/src/main/resources/application-cloud.yaml
+++ b/src/main/resources/application-cloud.yaml
@@ -9,20 +9,27 @@ spring:
       database: ${MONGODB_DATABASE}
   cache:
     type: redis
-
-
   threads:
     virtual:
       enabled: true
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
 
 springdoc:
+  api-docs:
+    enabled: false
   swagger-ui:
+    enabled: false
     schemes:
       - https
 
 server:
   forward-headers-strategy: native
   port: 10000
+  shutdown: graceful
+  error:
+    include-stacktrace: never
+    include-message: never
 
 s3:
   url: ${S3_URL}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -35,3 +35,12 @@ s3:
 jwt:
   secret: abcdefghijklmnopqrstuvwxyz1234567890
   expiration: 300000
+
+logging:
+  level:
+    com.kirjaswappi.backend.jpa.repositories.CustomBookRepositoryImpl: DEBUG
+    org:
+      springframework:
+        mail: DEBUG
+        boot:
+          actuate: DEBUG

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,8 +12,11 @@ spring:
     encoding: UTF-8
   servlet:
     multipart:
-      max-file-size: 100MB
-      max-request-size: 100MB
+      # Single image cap (book cover, profile/cover photo, chat attachment)
+      max-file-size: 10MB
+      # Total request cap allows up to ~5 cover photos in a single book
+      # creation multipart request.
+      max-request-size: 50MB
 
   mail:
     host: ${EMAIL_HOST}
@@ -70,12 +73,8 @@ resilience4j.retry:
 
 logging:
   level:
-    com.kirjaswappi.backend.jpa.repositories.CustomBookRepositoryImpl: DEBUG
     org:
       springframework:
-        mail: DEBUG
-        boot:
-          actuate: DEBUG
         security: INFO
 
 google:
@@ -87,6 +86,7 @@ notification:
     host: ${NOTIFICATION_SERVICE_HOST:notify.kirjaswappi.fi}
     port: ${NOTIFICATION_SERVICE_PORT:50051}
     enabled: ${NOTIFICATION_SERVICE_ENABLED:true}
+    apiKey: ${NOTIFICATION_API_KEY:}
 
 management:
   endpoints:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -79,7 +79,7 @@ logging:
 
 google:
   api:
-    clientId: 43921547457-06chtojpprgds80g1gq5tprmn5qg0hmq.apps.googleusercontent.com
+    clientId: ${GOOGLE_CLIENT_ID:43921547457-06chtojpprgds80g1gq5tprmn5qg0hmq.apps.googleusercontent.com}
 
 notification:
   service:
@@ -87,6 +87,7 @@ notification:
     port: ${NOTIFICATION_SERVICE_PORT:50051}
     enabled: ${NOTIFICATION_SERVICE_ENABLED:true}
     apiKey: ${NOTIFICATION_API_KEY:}
+    useTls: ${NOTIFICATION_SERVICE_USE_TLS:false}
 
 management:
   endpoints:

--- a/src/test/java/com/kirjaswappi/backend/common/service/NotificationServiceApiKeyTest.java
+++ b/src/test/java/com/kirjaswappi/backend/common/service/NotificationServiceApiKeyTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 KirjaSwappi or KirjaSwappi affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+package com.kirjaswappi.backend.common.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.grpc.CallCredentials;
+import io.grpc.Metadata;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contract test for the API-key metadata that the backend's gRPC client must
+ * attach when calling the Go notification service.
+ *
+ * <p>
+ * This used to be a silent launch blocker: the notification service rejects
+ * calls without {@code x-api-key} when {@code API_KEY} is set, but the Java
+ * client previously issued un-tagged requests and relied on the (then-empty)
+ * server-side default to "succeed".
+ */
+class NotificationServiceApiKeyTest {
+
+  private static final Metadata.Key<String> API_KEY = Metadata.Key.of("x-api-key",
+      Metadata.ASCII_STRING_MARSHALLER);
+
+  private static CallCredentials invokeFactory(String key) {
+    return NotificationService.apiKeyCallCredentials(key);
+  }
+
+  @Test
+  @DisplayName("apiKeyCallCredentials applies x-api-key metadata header")
+  void appliesApiKeyHeader() throws Exception {
+    CallCredentials creds = invokeFactory("super-secret");
+    AtomicReference<Metadata> applied = new AtomicReference<>();
+
+    creds.applyRequestMetadata(null, Runnable::run, new CallCredentials.MetadataApplier() {
+      @Override
+      public void apply(Metadata headers) {
+        applied.set(headers);
+      }
+
+      @Override
+      public void fail(io.grpc.Status status) {
+        throw new AssertionError("Should not fail: " + status);
+      }
+    });
+
+    Metadata headers = applied.get();
+    assertNotNull(headers, "MetadataApplier must be invoked synchronously");
+    assertEquals("super-secret", headers.get(API_KEY),
+        "x-api-key metadata must be present and equal to the configured key");
+  }
+
+  @Test
+  @DisplayName("Empty API key still produces credentials but no metadata leaks unrelated headers")
+  void differentKeysDoNotLeakAcross() throws Exception {
+    CallCredentials a = invokeFactory("alpha");
+    CallCredentials b = invokeFactory("bravo");
+    AtomicReference<Metadata> ha = new AtomicReference<>();
+    AtomicReference<Metadata> hb = new AtomicReference<>();
+
+    a.applyRequestMetadata(null, Runnable::run, new CallCredentials.MetadataApplier() {
+      @Override
+      public void apply(Metadata headers) {
+        ha.set(headers);
+      }
+
+      @Override
+      public void fail(io.grpc.Status status) {
+        throw new AssertionError(status.toString());
+      }
+    });
+    b.applyRequestMetadata(null, Runnable::run, new CallCredentials.MetadataApplier() {
+      @Override
+      public void apply(Metadata headers) {
+        hb.set(headers);
+      }
+
+      @Override
+      public void fail(io.grpc.Status status) {
+        throw new AssertionError(status.toString());
+      }
+    });
+
+    assertEquals("alpha", ha.get().get(API_KEY));
+    assertEquals("bravo", hb.get().get(API_KEY));
+    assertNull(ha.get().get(Metadata.Key.of("x-other-key", Metadata.ASCII_STRING_MARSHALLER)));
+  }
+}

--- a/src/test/java/com/kirjaswappi/backend/common/service/NotificationServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/common/service/NotificationServiceTest.java
@@ -42,7 +42,7 @@ class NotificationServiceTest {
   void setUp() {
     MockitoAnnotations.openMocks(this);
     // Initialize NotificationService manually to control @Value fields
-    notificationService = new NotificationService("localhost", 9090, true, "");
+    notificationService = new NotificationService("localhost", 9090, true, "", false);
 
     // Inject mocks using ReflectionTestUtils since they are not injected by
     // constructor
@@ -170,7 +170,7 @@ class NotificationServiceTest {
   @DisplayName("Should skip cleanup when disabled")
   void shouldSkipCleanupWhenDisabled() {
     // Given
-    NotificationService disabledService = new NotificationService("localhost", 9090, false, "");
+    NotificationService disabledService = new NotificationService("localhost", 9090, false, "", false);
     ReflectionTestUtils.setField(disabledService, "notificationOutboxRepository", notificationOutboxRepository);
 
     // When

--- a/src/test/java/com/kirjaswappi/backend/common/service/NotificationServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/common/service/NotificationServiceTest.java
@@ -42,7 +42,7 @@ class NotificationServiceTest {
   void setUp() {
     MockitoAnnotations.openMocks(this);
     // Initialize NotificationService manually to control @Value fields
-    notificationService = new NotificationService("localhost", 9090, true);
+    notificationService = new NotificationService("localhost", 9090, true, "");
 
     // Inject mocks using ReflectionTestUtils since they are not injected by
     // constructor
@@ -170,7 +170,7 @@ class NotificationServiceTest {
   @DisplayName("Should skip cleanup when disabled")
   void shouldSkipCleanupWhenDisabled() {
     // Given
-    NotificationService disabledService = new NotificationService("localhost", 9090, false);
+    NotificationService disabledService = new NotificationService("localhost", 9090, false, "");
     ReflectionTestUtils.setField(disabledService, "notificationOutboxRepository", notificationOutboxRepository);
 
     // When

--- a/src/test/java/com/kirjaswappi/backend/common/service/OTPServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/common/service/OTPServiceTest.java
@@ -24,7 +24,6 @@ import com.kirjaswappi.backend.common.service.entities.OTP;
 import com.kirjaswappi.backend.service.UserService;
 import com.kirjaswappi.backend.service.exceptions.BadRequestException;
 import com.kirjaswappi.backend.service.exceptions.ResourceNotFoundException;
-import com.kirjaswappi.backend.service.exceptions.UserNotFoundException;
 
 class OTPServiceTest {
   @Mock
@@ -126,10 +125,15 @@ class OTPServiceTest {
   }
 
   @Test
-  @DisplayName("Should throw exception when user not found for OTP")
-  void saveAndSendOTPThrowsWhenUserNotFound() {
+  @DisplayName("Should silently succeed when user not found (no account enumeration)")
+  void saveAndSendOTPSilentForUnknownUser() throws Exception {
+    // Audit F8: /send-otp must not leak whether an account exists. The service
+    // returns the email and skips the OTP/email path for unknown addresses.
     when(userService.checkIfUserExists(email)).thenReturn(false);
-    assertThrows(UserNotFoundException.class, () -> otpService.saveAndSendOTP(email));
+    assertEquals(email, otpService.saveAndSendOTP(email));
+    verify(otpRepository, never()).save(org.mockito.ArgumentMatchers.any());
+    verify(emailService, never()).sendOTPByEmail(org.mockito.ArgumentMatchers.anyString(),
+        org.mockito.ArgumentMatchers.anyString());
   }
 
   @Test

--- a/src/test/java/com/kirjaswappi/backend/common/service/ProfanityFilterServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/common/service/ProfanityFilterServiceTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 KirjaSwappi or KirjaSwappi affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+package com.kirjaswappi.backend.common.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ProfanityFilterServiceTest {
+
+  private final ProfanityFilterService service = new ProfanityFilterService();
+
+  @Test
+  @DisplayName("Returns null when input is null")
+  void filterNull() {
+    assertNull(service.filter(null));
+  }
+
+  @Test
+  @DisplayName("Leaves clean text untouched")
+  void filterCleanText() {
+    String text = "I love reading books in the park.";
+    assertEquals(text, service.filter(text));
+  }
+
+  @Test
+  @DisplayName("Replaces a single banned word with asterisks")
+  void filterReplacesSingleWord() {
+    assertEquals("*** off", service.filter("fuck off"));
+  }
+
+  @Test
+  @DisplayName("Replaces all occurrences of multiple banned words")
+  void filterReplacesMultipleWords() {
+    assertEquals("*** *** ***", service.filter("shit fuck bitch"));
+  }
+
+  @Test
+  @DisplayName("Matches whole words case-insensitively")
+  void filterCaseInsensitive() {
+    assertEquals("*** you", service.filter("FUCK you"));
+  }
+
+  @Test
+  @DisplayName("Does not strip non-word substrings (whole-word boundary)")
+  void filterRespectsWordBoundary() {
+    // 'classic' contains 'lass' — must NOT be considered a substring match for
+    // any banned word; verify by leaving a benign sentence intact.
+    String text = "We are reading a classic novel.";
+    assertEquals(text, service.filter(text));
+  }
+
+  @Test
+  @DisplayName("Preserves surrounding punctuation when censoring")
+  void filterKeepsPunctuation() {
+    assertEquals("Stop, ***!", service.filter("Stop, fuck!"));
+  }
+}

--- a/src/test/java/com/kirjaswappi/backend/common/service/RateLimiterServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/common/service/RateLimiterServiceTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 KirjaSwappi or KirjaSwappi affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+package com.kirjaswappi.backend.common.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+class RateLimiterServiceTest {
+
+  private StringRedisTemplate redisTemplate;
+  private ValueOperations<String, String> valueOps;
+  private RateLimiterService rateLimiterService;
+
+  @BeforeEach
+  @SuppressWarnings("unchecked")
+  void setUp() {
+    redisTemplate = mock(StringRedisTemplate.class);
+    valueOps = mock(ValueOperations.class);
+    when(redisTemplate.opsForValue()).thenReturn(valueOps);
+    rateLimiterService = new RateLimiterService(redisTemplate);
+  }
+
+  @Test
+  @DisplayName("isRateLimited returns false when no attempts recorded")
+  void isRateLimitedReturnsFalseWhenNoAttempts() {
+    when(valueOps.get("k")).thenReturn(null);
+    assertFalse(rateLimiterService.isRateLimited("k", 5));
+  }
+
+  @Test
+  @DisplayName("isRateLimited returns true when attempts >= max")
+  void isRateLimitedReturnsTrueWhenOverThreshold() {
+    when(valueOps.get("k")).thenReturn("5");
+    assertTrue(rateLimiterService.isRateLimited("k", 5));
+  }
+
+  @Test
+  @DisplayName("isRateLimited fails OPEN when Redis throws (legacy callers)")
+  void isRateLimitedFailsOpenOnRedisError() {
+    when(valueOps.get("k")).thenThrow(new RedisConnectionFailureException("down"));
+    assertFalse(rateLimiterService.isRateLimited("k", 5));
+  }
+
+  @Test
+  @DisplayName("isRateLimitedFailClosed fails CLOSED when Redis throws")
+  void isRateLimitedFailClosedFailsClosedOnRedisError() {
+    when(valueOps.get("k")).thenThrow(new RedisConnectionFailureException("down"));
+    assertTrue(rateLimiterService.isRateLimitedFailClosed("k", 5));
+  }
+
+  @Test
+  @DisplayName("isRateLimitedFailClosed returns true at threshold")
+  void isRateLimitedFailClosedHonoursThreshold() {
+    when(valueOps.get("k")).thenReturn("10");
+    assertTrue(rateLimiterService.isRateLimitedFailClosed("k", 10));
+  }
+
+  @Test
+  @DisplayName("recordAttempt swallows Redis errors")
+  void recordAttemptSwallowsErrors() {
+    when(valueOps.increment("k")).thenThrow(new RedisConnectionFailureException("down"));
+    rateLimiterService.recordAttempt("k", Duration.ofMinutes(15));
+  }
+}

--- a/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/BookControllerEdgeCaseTest.java
+++ b/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/BookControllerEdgeCaseTest.java
@@ -51,11 +51,14 @@ class BookControllerEdgeCaseTest {
   @MockitoBean
   private BookService bookService;
 
+  // Minimal JPEG SOI marker so ValidationUtil's magic-byte check passes.
+  private static final byte[] JPEG_BYTES = new byte[] { (byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0,
+      0, 16, 'J', 'F', 'I', 'F', 0, 1, 1, 0, 0, 1, 0, 1, 0, 0 };
   private final MockMultipartFile coverPhoto = new MockMultipartFile(
       "coverPhotos",
       "book.jpg",
       MediaType.IMAGE_JPEG_VALUE,
-      "dummy".getBytes());
+      JPEG_BYTES);
 
   @Nested
   @DisplayName("Location-Based Query Edge Cases")
@@ -267,6 +270,7 @@ class BookControllerEdgeCaseTest {
           .param("condition", "Good")
           .param("genres", "Fiction")
           .param("ownerId", "user-123")
+          .principal(() -> "user-123")
           .param("swapCondition", swapCondition))
           .andExpect(status().isBadRequest());
     }
@@ -291,6 +295,7 @@ class BookControllerEdgeCaseTest {
           .param("condition", "Good")
           .param("genres", "Fiction")
           .param("ownerId", "user-123")
+          .principal(() -> "user-123")
           .param("swapCondition", swapCondition))
           .andExpect(status().isBadRequest());
     }
@@ -315,13 +320,14 @@ class BookControllerEdgeCaseTest {
           .param("language", "English")
           .param("genres", "Fiction")
           .param("ownerId", "user-123")
+          .principal(() -> "user-123")
           .param("swapCondition", swapCondition))
           .andExpect(status().isBadRequest());
     }
 
     @Test
-    @DisplayName("Should return 400 when ownerId is missing")
-    void shouldReturn400WhenOwnerIdMissing() throws Exception {
+    @DisplayName("Should return 401 when create book is anonymous (no principal)")
+    void shouldReturn401WhenAnonymousCreate() throws Exception {
       String swapCondition = """
           {
             "swapType": "GiveAway",
@@ -340,7 +346,7 @@ class BookControllerEdgeCaseTest {
           .param("condition", "Good")
           .param("genres", "Fiction")
           .param("swapCondition", swapCondition))
-          .andExpect(status().isBadRequest());
+          .andExpect(status().isForbidden());
     }
 
     @Test
@@ -353,7 +359,7 @@ class BookControllerEdgeCaseTest {
           .param("language", "English")
           .param("condition", "Good")
           .param("genres", "Fiction")
-          .param("ownerId", "user-123"))
+          .principal(() -> "user-123"))
           .andExpect(status().isBadRequest());
     }
   }
@@ -446,6 +452,7 @@ class BookControllerEdgeCaseTest {
           .param("condition", "Good")
           .param("genres", "Fiction")
           .param("ownerId", "user-123")
+          .principal(() -> "user-123")
           .param("swapCondition", "not-valid-json"))
           .andExpect(status().isBadRequest());
     }
@@ -469,6 +476,7 @@ class BookControllerEdgeCaseTest {
           .param("condition", "Good")
           .param("genres", "Fiction")
           .param("ownerId", "user-123")
+          .principal(() -> "user-123")
           .param("swapCondition", swapCondition)
           .param("location", "not-valid-json"))
           .andExpect(status().isBadRequest());
@@ -492,6 +500,7 @@ class BookControllerEdgeCaseTest {
           .param("condition", "Good")
           .param("genres", "Fiction")
           .param("ownerId", "user-123")
+          .principal(() -> "user-123")
           .param("swapCondition", swapCondition))
           .andExpect(status().isBadRequest());
     }
@@ -514,6 +523,7 @@ class BookControllerEdgeCaseTest {
           .param("language", "English")
           .param("condition", "Good")
           .param("ownerId", "user-123")
+          .principal(() -> "user-123")
           .param("swapCondition", swapCondition))
           .andExpect(status().isBadRequest());
     }
@@ -522,7 +532,8 @@ class BookControllerEdgeCaseTest {
     @DisplayName("Should return 400 for malformed multipart request")
     void shouldReturn400ForMalformedRequest() throws Exception {
       mockMvc.perform(multipart(API_BASE)
-          .file(coverPhoto))
+          .file(coverPhoto)
+          .principal(() -> "user-123"))
           .andExpect(status().isBadRequest());
     }
   }

--- a/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/BookControllerTest.java
+++ b/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/BookControllerTest.java
@@ -49,8 +49,11 @@ class BookControllerTest {
 
   private static final String BASE_PATH = API_BASE + BOOKS;
 
+  // Minimal JPEG SOI marker so ValidationUtil's magic-byte check passes.
+  private static final byte[] JPEG_BYTES = new byte[] { (byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0,
+      0, 16, 'J', 'F', 'I', 'F', 0, 1, 1, 0, 0, 1, 0, 1, 0, 0 };
   MockMultipartFile coverPhoto = new MockMultipartFile("coverPhotos", "book.jpg", MediaType.IMAGE_JPEG_VALUE,
-      "dummy".getBytes());
+      JPEG_BYTES);
 
   @Test
   @DisplayName("Should create a Book with swap type ByBooks successfully")
@@ -82,6 +85,7 @@ class BookControllerTest {
         .param("condition", "New")
         .param("genres", "Fiction")
         .param("ownerId", "user-123")
+        .principal(() -> "user-123")
         .param("swapCondition", swapCondition))
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.title").value("The Alchemist"));
@@ -112,6 +116,7 @@ class BookControllerTest {
         .param("condition", "New")
         .param("genres", "Fiction")
         .param("ownerId", "user-123")
+        .principal(() -> "user-123")
         .param("swapCondition", swapCondition))
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.title").value("The Alchemist"));
@@ -143,6 +148,7 @@ class BookControllerTest {
         .param("condition", "New")
         .param("genres", "Fiction")
         .param("ownerId", "user-123")
+        .principal(() -> "user-123")
         .param("swapCondition", swapCondition))
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.title").value("The Alchemist"));
@@ -173,6 +179,7 @@ class BookControllerTest {
         .param("condition", "New")
         .param("genres", "Fiction")
         .param("ownerId", "user-123")
+        .principal(() -> "user-123")
         .param("swapCondition", swapCondition))
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.title").value("The Alchemist"));
@@ -211,6 +218,7 @@ class BookControllerTest {
         .param("condition", "New")
         .param("genres", "Fiction")
         .param("ownerId", "user-123")
+        .principal(() -> "user-123")
         .param("swapCondition", swapCondition)
         .with(request -> {
           request.setMethod("PUT");
@@ -249,6 +257,7 @@ class BookControllerTest {
         .param("condition", "New")
         .param("genres", "Fiction")
         .param("ownerId", "user-123")
+        .principal(() -> "user-123")
         .param("swapCondition", swapCondition)
         .with(request -> {
           request.setMethod("PUT");
@@ -287,6 +296,7 @@ class BookControllerTest {
         .param("condition", "New")
         .param("genres", "Fiction")
         .param("ownerId", "user-123")
+        .principal(() -> "user-123")
         .param("swapCondition", swapCondition)
         .with(request -> {
           request.setMethod("PUT");
@@ -325,6 +335,7 @@ class BookControllerTest {
         .param("condition", "New")
         .param("genres", "Fiction")
         .param("ownerId", "user-123")
+        .principal(() -> "user-123")
         .param("swapCondition", swapCondition)
         .with(request -> {
           request.setMethod("PUT");

--- a/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/PhotoControllerTest.java
+++ b/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/PhotoControllerTest.java
@@ -41,10 +41,13 @@ class PhotoControllerTest {
   private final String userId = "user123";
   private final String email = "test@example.com";
   private final String photoUrl = "http://example.com/photo.jpg";
+  // Minimal JPEG SOI marker so ValidationUtil's magic-byte check passes.
+  private static final byte[] JPEG_BYTES = new byte[] { (byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0,
+      0, 16, 'J', 'F', 'I', 'F', 0, 1, 1, 0, 0, 1, 0, 1, 0, 0 };
   private final MockMultipartFile file = new MockMultipartFile("image", "photo.jpg", MediaType.IMAGE_JPEG_VALUE,
-      "dummy".getBytes());
+      JPEG_BYTES);
   private final MockMultipartFile supportedCoverPhoto = new MockMultipartFile("coverPhoto", "photo.jpg",
-      MediaType.IMAGE_JPEG_VALUE, "dummy".getBytes());
+      MediaType.IMAGE_JPEG_VALUE, JPEG_BYTES);
 
   @Test
   @WithMockUser(username = "user123")

--- a/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/UserControllerTest.java
+++ b/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/UserControllerTest.java
@@ -246,7 +246,7 @@ public class UserControllerTest {
     request.setConfirmPassword("newPassword1!");
     request.setResetToken("valid-reset-token");
 
-    when(jwtUtil.validatePasswordResetToken("valid-reset-token")).thenReturn(true);
+    when(jwtUtil.validateAndConsumePasswordResetToken("valid-reset-token")).thenReturn(true);
     when(jwtUtil.extractEmailFromResetToken("valid-reset-token")).thenReturn("test@example.com");
     when(userService.changePassword(any())).thenReturn("test@example.com");
 

--- a/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/UserControllerTest.java
+++ b/src/test/java/com/kirjaswappi/backend/http/controllers/mockMvc/UserControllerTest.java
@@ -150,7 +150,8 @@ public class UserControllerTest {
   }
 
   @Test
-  @DisplayName("Should get user by ID")
+  @WithMockUser(username = "1")
+  @DisplayName("Should get full user profile when authenticated as same user")
   void shouldGetUser() throws Exception {
     when(userService.getUser("1")).thenReturn(user);
 
@@ -158,6 +159,23 @@ public class UserControllerTest {
         .header("Authorization ", "Bearer a.b.c"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.email").value(user.email()));
+  }
+
+  @Test
+  @WithMockUser(username = "2")
+  @DisplayName("Should return only public profile fields when viewing another user")
+  void shouldReturnPublicProfileForOtherUser() throws Exception {
+    when(userService.getUser("1")).thenReturn(user);
+
+    mockMvc.perform(get(API_BASE + "/1")
+        .header("Authorization ", "Bearer a.b.c"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value("1"))
+        .andExpect(jsonPath("$.email").doesNotExist())
+        .andExpect(jsonPath("$.phoneNumber").doesNotExist())
+        .andExpect(jsonPath("$.streetName").doesNotExist())
+        .andExpect(jsonPath("$.houseNumber").doesNotExist())
+        .andExpect(jsonPath("$.zipCode").doesNotExist());
   }
 
   @Test
@@ -200,6 +218,7 @@ public class UserControllerTest {
   }
 
   @Test
+  @WithMockUser(username = "1")
   @DisplayName("Should change user password")
   void shouldChangePassword() throws Exception {
     ChangePasswordRequest request = new ChangePasswordRequest();
@@ -207,6 +226,7 @@ public class UserControllerTest {
     request.setNewPassword("newPassword1!");
     request.setConfirmPassword("newPassword1!");
 
+    when(userService.getUser("1")).thenReturn(user);
     Mockito.doNothing().when(userService).verifyCurrentPassword(any());
     when(userService.changePassword(any())).thenReturn("test@example.com");
 
@@ -535,8 +555,11 @@ public class UserControllerTest {
   }
 
   @Test
+  @WithMockUser(username = "1")
   @DisplayName("Should return 400 when new and confirm password do not match")
   void shouldReturnBadRequestWhenPasswordsDoNotMatch() throws Exception {
+    when(userService.getUser("1")).thenReturn(user);
+
     ChangePasswordRequest request = new ChangePasswordRequest();
     request.setCurrentPassword("currentPassword");
     request.setNewPassword("newPassword1!");
@@ -547,6 +570,24 @@ public class UserControllerTest {
         .content(objectMapper.writeValueAsString(request))
         .header("Authorization", "Bearer a.b.c"))
         .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(username = "1")
+  @DisplayName("Should return 403 when path email differs from authenticated user")
+  void shouldRejectChangePasswordForOtherUserEmail() throws Exception {
+    when(userService.getUser("1")).thenReturn(user);
+
+    ChangePasswordRequest request = new ChangePasswordRequest();
+    request.setCurrentPassword("currentPassword");
+    request.setNewPassword("newPassword1!");
+    request.setConfirmPassword("newPassword1!");
+
+    mockMvc.perform(post(API_BASE + "/change-password/other@example.com")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(request))
+        .header("Authorization", "Bearer a.b.c"))
+        .andExpect(status().isForbidden());
   }
 
   @Test

--- a/src/test/java/com/kirjaswappi/backend/integration/BookApiIntegrationTest.java
+++ b/src/test/java/com/kirjaswappi/backend/integration/BookApiIntegrationTest.java
@@ -52,11 +52,14 @@ class BookApiIntegrationTest {
   @MockitoBean
   private BookService bookService;
 
+  // Minimal JPEG SOI marker so ValidationUtil's magic-byte check passes.
+  private static final byte[] JPEG_BYTES = new byte[] { (byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0,
+      0, 16, 'J', 'F', 'I', 'F', 0, 1, 1, 0, 0, 1, 0, 1, 0, 0 };
   private final MockMultipartFile coverPhoto = new MockMultipartFile(
       "coverPhotos",
       "book.jpg",
       MediaType.IMAGE_JPEG_VALUE,
-      "dummy image content".getBytes());
+      JPEG_BYTES);
 
   private User createTestUser() {
     return User.builder()
@@ -133,6 +136,7 @@ class BookApiIntegrationTest {
           .param("condition", "New")
           .param("genres", "Fiction")
           .param("ownerId", "user-123")
+          .principal(() -> "user-123")
           .param("swapCondition", swapCondition))
           .andExpect(status().isCreated());
     }
@@ -162,6 +166,7 @@ class BookApiIntegrationTest {
           .param("condition", "Good")
           .param("genres", "Fiction")
           .param("ownerId", "user-123")
+          .principal(() -> "user-123")
           .param("swapCondition", swapCondition))
           .andExpect(status().isCreated());
     }
@@ -190,6 +195,7 @@ class BookApiIntegrationTest {
           .param("condition", "Fair")
           .param("genres", "Fiction")
           .param("ownerId", "user-123")
+          .principal(() -> "user-123")
           .param("swapCondition", swapCondition))
           .andExpect(status().isCreated());
     }
@@ -218,6 +224,7 @@ class BookApiIntegrationTest {
           .param("condition", "Like New")
           .param("genres", "Fiction")
           .param("ownerId", "user-123")
+          .principal(() -> "user-123")
           .param("swapCondition", swapCondition))
           .andExpect(status().isCreated());
     }
@@ -246,6 +253,7 @@ class BookApiIntegrationTest {
           .param("condition", "Good")
           .param("genres", "Fiction")
           .param("ownerId", "user-123")
+          .principal(() -> "user-123")
           .param("swapCondition", swapCondition)
           .param("location.latitude", "60.1699")
           .param("location.longitude", "24.9384")
@@ -292,6 +300,7 @@ class BookApiIntegrationTest {
           .param("condition", "Good")
           .param("genres", "Fiction")
           .param("ownerId", "user-123")
+          .principal(() -> "user-123")
           .param("swapCondition", swapCondition)
           .param("location", locationJson))
           .andExpect(status().isCreated());
@@ -317,6 +326,7 @@ class BookApiIntegrationTest {
           .param("condition", "Good")
           .param("genres", "Fiction")
           .param("ownerId", "user-123")
+          .principal(() -> "user-123")
           .param("swapCondition", swapCondition))
           .andExpect(status().isBadRequest());
     }
@@ -332,6 +342,7 @@ class BookApiIntegrationTest {
           .param("condition", "Good")
           .param("genres", "Fiction")
           .param("ownerId", "user-123")
+          .principal(() -> "user-123")
           .param("swapCondition", "invalid json"))
           .andExpect(status().isBadRequest());
     }

--- a/src/test/java/com/kirjaswappi/backend/integration/PhotoApiIntegrationTest.java
+++ b/src/test/java/com/kirjaswappi/backend/integration/PhotoApiIntegrationTest.java
@@ -51,16 +51,19 @@ class PhotoApiIntegrationTest {
   private final String userId = "user-123";
   private final String email = "test@example.com";
   private final String photoUrl = "https://storage.example.com/photos/test.jpg";
+  // Minimal JPEG SOI marker so ValidationUtil's magic-byte check passes.
+  private static final byte[] JPEG_BYTES = new byte[] { (byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0,
+      0, 16, 'J', 'F', 'I', 'F', 0, 1, 1, 0, 0, 1, 0, 1, 0, 0 };
   private final MockMultipartFile imageFile = new MockMultipartFile(
       "image",
       "photo.jpg",
       MediaType.IMAGE_JPEG_VALUE,
-      "test image content".getBytes());
+      JPEG_BYTES);
   private final MockMultipartFile supportedCoverPhotoFile = new MockMultipartFile(
       "coverPhoto",
       "cover.jpg",
       MediaType.IMAGE_JPEG_VALUE,
-      "cover image content".getBytes());
+      JPEG_BYTES);
 
   @Nested
   @DisplayName("Profile Photo Tests")

--- a/src/test/java/com/kirjaswappi/backend/integration/UserApiIntegrationTest.java
+++ b/src/test/java/com/kirjaswappi/backend/integration/UserApiIntegrationTest.java
@@ -21,11 +21,13 @@ import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kirjaswappi.backend.common.service.RateLimiterService;
 import com.kirjaswappi.backend.config.TestContainersConfig;
 import com.kirjaswappi.backend.http.dtos.requests.*;
 import com.kirjaswappi.backend.jpa.daos.BookDao;
@@ -64,6 +66,11 @@ class UserApiIntegrationTest {
 
   @Autowired
   private ObjectMapper objectMapper;
+
+  // Bypass the real rate limiter (which would otherwise hit a missing Redis in
+  // this lightweight integration test) so we can exercise auth flows directly.
+  @MockitoBean
+  private RateLimiterService rateLimiterService;
 
   private MockMvc mockMvc;
 
@@ -358,15 +365,18 @@ class UserApiIntegrationTest {
   class GetUserTests {
 
     @Test
-    @DisplayName("Should return user by ID")
+    @DisplayName("Should return public profile when viewing another user")
     void shouldReturnUserById() throws Exception {
       UserDao user = createTestUser("Test", "User", "test@example.com");
 
+      // Anonymous (or non-self) callers receive PublicUserResponse: name + city
+      // only. Email and other PII are intentionally hidden — see audit A1.
       mockMvc.perform(get(API_BASE + "/" + user.id()))
           .andExpect(status().isOk())
-          .andExpect(jsonPath("$.email").value("test@example.com"))
           .andExpect(jsonPath("$.firstName").value("Test"))
-          .andExpect(jsonPath("$.lastName").value("User"));
+          .andExpect(jsonPath("$.lastName").value("User"))
+          .andExpect(jsonPath("$.email").doesNotExist())
+          .andExpect(jsonPath("$.phoneNumber").doesNotExist());
     }
 
     @Test
@@ -577,8 +587,10 @@ class UserApiIntegrationTest {
   class PasswordManagementTests {
 
     @Test
-    @DisplayName("Should return 400 when passwords do not match for change password")
+    @DisplayName("Should return 403 when changing another user's password")
     void shouldReturn400WhenPasswordsMismatchForChangePassword() throws Exception {
+      // Without an authenticated principal matching the path email, the
+      // controller now refuses with 403 (audit B6: tied to authenticated user).
       ChangePasswordRequest request = new ChangePasswordRequest();
       request.setCurrentPassword("currentPassword");
       request.setNewPassword("newPassword");
@@ -587,7 +599,7 @@ class UserApiIntegrationTest {
       mockMvc.perform(post(API_BASE + "/change-password/test@example.com")
           .contentType(MediaType.APPLICATION_JSON)
           .content(objectMapper.writeValueAsString(request)))
-          .andExpect(status().isBadRequest());
+          .andExpect(status().isForbidden());
     }
 
     @Test

--- a/src/test/java/com/kirjaswappi/backend/service/ChatServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/service/ChatServiceTest.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,6 +31,7 @@ import com.kirjaswappi.backend.jpa.daos.SwapRequestDao;
 import com.kirjaswappi.backend.jpa.daos.UserDao;
 import com.kirjaswappi.backend.jpa.repositories.ChatMessageRepository;
 import com.kirjaswappi.backend.jpa.repositories.SwapRequestRepository;
+import com.kirjaswappi.backend.jpa.repositories.UserRepository;
 import com.kirjaswappi.backend.service.entities.ChatMessage;
 import com.kirjaswappi.backend.service.entities.SwapRequest;
 import com.kirjaswappi.backend.service.entities.User;
@@ -46,6 +46,8 @@ class ChatServiceTest {
   private SwapRequestRepository swapRequestRepository;
   @Mock
   private UserService userService;
+  @Mock
+  private UserRepository userRepository;
   @Mock
   private ImageService imageService;
   @Mock
@@ -66,6 +68,10 @@ class ChatServiceTest {
   @BeforeEach
   void setUp() {
     MockitoAnnotations.openMocks(this);
+
+    // Default: no users have anyone blocked. Tests that need a block override.
+    when(userRepository.findById(org.mockito.ArgumentMatchers.anyString()))
+        .thenReturn(java.util.Optional.empty());
 
     // Create test users
     senderDao = UserDao.builder()
@@ -249,7 +255,7 @@ class ChatServiceTest {
     String receiverHex = "64e8f5d1a2b3c4d5e6f78901";
 
     when(chatMessageRepository.countBySwapRequestIdAndReadByReceiverFalseAndSenderIdNot("swap123",
-        new ObjectId(receiverHex)))
+        new org.bson.types.ObjectId(receiverHex)))
             .thenReturn(3L);
 
     // When
@@ -259,7 +265,7 @@ class ChatServiceTest {
     assertEquals(3L, count);
     verify(swapRequestRepository).findById("swap123");
     verify(chatMessageRepository).countBySwapRequestIdAndReadByReceiverFalseAndSenderIdNot("swap123",
-        new ObjectId(receiverHex));
+        new org.bson.types.ObjectId(receiverHex));
   }
 
   @Test
@@ -561,7 +567,7 @@ class ChatServiceTest {
     // Given
     when(swapRequestRepository.findById("swap123")).thenReturn(Optional.of(swapRequestDao));
     when(chatMessageRepository.countBySwapRequestIdAndReadByReceiverFalseAndSenderIdNot("swap123",
-        new ObjectId("64e8f5d1a2b3c4d5e6f78901")))
+        new org.bson.types.ObjectId("64e8f5d1a2b3c4d5e6f78901")))
             .thenReturn(0L);
 
     // When
@@ -570,7 +576,7 @@ class ChatServiceTest {
     // Then
     assertEquals(0L, count);
     verify(chatMessageRepository).countBySwapRequestIdAndReadByReceiverFalseAndSenderIdNot("swap123",
-        new ObjectId("64e8f5d1a2b3c4d5e6f78901"));
+        new org.bson.types.ObjectId("64e8f5d1a2b3c4d5e6f78901"));
   }
 
   @Test

--- a/src/test/java/com/kirjaswappi/backend/service/ChatServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/service/ChatServiceTest.java
@@ -56,6 +56,8 @@ class ChatServiceTest {
   private ProfanityFilterService profanityFilterService;
   @Mock
   private org.springframework.cache.CacheManager cacheManager;
+  @Mock
+  private org.springframework.data.mongodb.core.MongoTemplate mongoTemplate;
   @InjectMocks
   private ChatService chatService;
 

--- a/src/test/java/com/kirjaswappi/backend/service/SwapServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/service/SwapServiceTest.java
@@ -293,6 +293,7 @@ class SwapServiceTest {
         .language(Language.ENGLISH)
         .condition(Condition.GOOD)
         .swapCondition(swapCondition)
+        .owner(User.builder().id("receiverId").build())
         .build();
 
     var swapOffer = SwapOffer.builder()
@@ -384,6 +385,7 @@ class SwapServiceTest {
         .language(Language.ENGLISH)
         .condition(Condition.GOOD)
         .swapCondition(swapCondition)
+        .owner(User.builder().id("receiverId").build())
         .build();
 
     var swapOffer = SwapOffer.builder()
@@ -745,6 +747,8 @@ class SwapServiceTest {
         .lastName("Doe")
         .books(List.of());
 
+    var receiver = new User().id("receiverId");
+
     var swapCondition = new SwapCondition()
         .swappableBooks(List.of())
         .swappableGenres(List.of())
@@ -758,9 +762,10 @@ class SwapServiceTest {
         .language(Language.ENGLISH)
         .condition(Condition.GOOD)
         .swapCondition(swapCondition)
+        .owner(User.builder().id("receiverId").build())
         .build();
 
-    var receiver = new User().id("receiverId").books(List.of(book));
+    receiver.books(List.of(book));
 
     var swapRequest = SwapRequest.builder()
         .sender(sender)
@@ -797,6 +802,8 @@ class SwapServiceTest {
         .lastName("Doe")
         .books(List.of());
 
+    var receiver = new User().id("receiverId");
+
     var swapCondition = new SwapCondition()
         .swappableBooks(List.of())
         .swappableGenres(List.of())
@@ -810,9 +817,10 @@ class SwapServiceTest {
         .language(Language.ENGLISH)
         .condition(Condition.GOOD)
         .swapCondition(swapCondition)
+        .owner(User.builder().id("receiverId").build())
         .build();
 
-    var receiver = new User().id("receiverId").books(List.of(book));
+    receiver.books(List.of(book));
 
     var swapRequest = SwapRequest.builder()
         .sender(sender)
@@ -850,6 +858,8 @@ class SwapServiceTest {
         .lastName("Doe")
         .books(List.of());
 
+    var receiver = new User().id("receiverId");
+
     var swapCondition = new SwapCondition().swappableBooks(List.of())
         .swappableGenres(List.of())
         .swapType(SwapType.BY_BOOKS)
@@ -862,9 +872,10 @@ class SwapServiceTest {
         .language(Language.ENGLISH)
         .condition(Condition.GOOD)
         .swapCondition(swapCondition)
+        .owner(User.builder().id("receiverId").build())
         .build();
 
-    var receiver = new User().id("receiverId").books(List.of(book));
+    receiver.books(List.of(book));
 
     var swapRequest = SwapRequest.builder()
         .sender(sender)

--- a/src/test/java/com/kirjaswappi/backend/service/SwapServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/service/SwapServiceTest.java
@@ -28,6 +28,7 @@ import com.kirjaswappi.backend.jpa.daos.SwapRequestDao;
 import com.kirjaswappi.backend.jpa.daos.SwappableBookDao;
 import com.kirjaswappi.backend.jpa.daos.UserDao;
 import com.kirjaswappi.backend.jpa.repositories.SwapRequestRepository;
+import com.kirjaswappi.backend.jpa.repositories.UserRepository;
 import com.kirjaswappi.backend.service.entities.Book;
 import com.kirjaswappi.backend.service.entities.Genre;
 import com.kirjaswappi.backend.service.entities.SwapCondition;
@@ -50,17 +51,26 @@ class SwapServiceTest {
   @Mock
   private UserService userService;
   @Mock
+  private UserRepository userRepository;
+  @Mock
   private BookService bookService;
   @Mock
   private GenreService genreService;
   @Mock
   private NotificationClient notificationClient;
+  @Mock
+  private PhotoService photoService;
   @InjectMocks
   private SwapService swapService;
 
   @BeforeEach
   void setUp() {
     MockitoAnnotations.openMocks(this);
+    // Default: no users have anyone blocked. Tests that need a block must
+    // override this stub explicitly.
+    when(userRepository.findById(anyString())).thenReturn(Optional.empty());
+    // Cover photo resolution is a no-op for tests that don't care about URLs.
+    when(photoService.getBookCoverPhoto(anyString())).thenAnswer(inv -> inv.getArgument(0));
   }
 
   @Test
@@ -901,7 +911,7 @@ class SwapServiceTest {
     verify(notificationClient).sendNotification(
         eq("sender123"),
         eq("Swap Request Update"),
-        eq("Your swap request for 'Amazing Book' has been accepted"));
+        eq("Swap request for 'Amazing Book' has been accepted"));
   }
 
   @Test

--- a/src/test/java/com/kirjaswappi/backend/service/SwapServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/service/SwapServiceTest.java
@@ -77,15 +77,15 @@ class SwapServiceTest {
   @DisplayName("Should throw SwapRequestExistsAlreadyException when swap request already exists")
   void createSwapRequestThrowsWhenExistsAlready() {
     var sender = User.builder()
-        .id("senderId")
+        .id("aaaaaaaaaaaaaaaaaaaaaaaa")
         .build();
 
     var receiver = User.builder()
-        .id("receiverId")
+        .id("bbbbbbbbbbbbbbbbbbbbbbbb")
         .build();
 
     var book = Book.builder()
-        .id("bookId")
+        .id("cccccccccccccccccccccccc")
         .build();
 
     var swapRequest = SwapRequest.builder()
@@ -93,7 +93,7 @@ class SwapServiceTest {
         .receiver(receiver)
         .bookToSwapWith(book)
         .build();
-    when(swapRequestRepository.existsAlready("senderId", "receiverId", "bookId")).thenReturn(true);
+    when(swapRequestRepository.existsAlready(any(), any(), any())).thenReturn(true);
     assertThrows(SwapRequestExistsAlreadyException.class, () -> swapService.createSwapRequest(swapRequest));
   }
 
@@ -101,16 +101,16 @@ class SwapServiceTest {
   @DisplayName("Should create swap request successfully when not duplicate")
   void createSwapRequestSuccess() {
     var sender = User.builder()
-        .id("senderId")
+        .id("aaaaaaaaaaaaaaaaaaaaaaaa")
         .build();
 
     var receiver = User.builder()
-        .id("receiverId")
+        .id("bbbbbbbbbbbbbbbbbbbbbbbb")
         .books(java.util.List.of())
         .build();
 
     var book = Book.builder()
-        .id("bookId")
+        .id("cccccccccccccccccccccccc")
         .swapCondition(null)
         .build();
 
@@ -121,10 +121,10 @@ class SwapServiceTest {
         .swapType(SwapType.BY_BOOKS)
         .swapStatus(SwapStatus.PENDING)
         .build();
-    when(swapRequestRepository.existsAlready("senderId", "receiverId", "bookId")).thenReturn(false);
-    when(userService.getUser("senderId")).thenReturn(sender);
-    when(userService.getUser("receiverId")).thenReturn(receiver);
-    when(bookService.getBookById("bookId")).thenReturn(book);
+    when(swapRequestRepository.existsAlready(any(), any(), any())).thenReturn(false);
+    when(userService.getUser("aaaaaaaaaaaaaaaaaaaaaaaa")).thenReturn(sender);
+    when(userService.getUser("bbbbbbbbbbbbbbbbbbbbbbbb")).thenReturn(receiver);
+    when(bookService.getBookById("cccccccccccccccccccccccc")).thenReturn(book);
     when(swapRequestRepository.save(any())).thenReturn(null);
     // receiver has no books, so IllegalSwapRequestException expected
     assertThrows(IllegalSwapRequestException.class, () -> swapService.createSwapRequest(swapRequest));
@@ -141,7 +141,7 @@ class SwapServiceTest {
   @DisplayName("Should throw when book to swap with does not belong to receiver")
   void createSwapRequestThrowsWhenBookNotBelongToReceiver() {
     var sender = User.builder()
-        .id("senderId")
+        .id("aaaaaaaaaaaaaaaaaaaaaaaa")
         .build();
 
     var otherBook = Book.builder()
@@ -149,7 +149,7 @@ class SwapServiceTest {
         .build();
 
     var receiver = User.builder()
-        .id("receiverId")
+        .id("bbbbbbbbbbbbbbbbbbbbbbbb")
         .books(List.of(otherBook))
         .build();
 
@@ -159,7 +159,7 @@ class SwapServiceTest {
         .build();
 
     var book = Book.builder()
-        .id("bookId")
+        .id("cccccccccccccccccccccccc")
         .swapCondition(swapCondition)
         .build();
 
@@ -170,10 +170,10 @@ class SwapServiceTest {
         .swapType(SwapType.BY_BOOKS)
         .swapStatus(SwapStatus.PENDING)
         .build();
-    when(swapRequestRepository.existsAlready("senderId", "receiverId", "bookId")).thenReturn(false);
-    when(userService.getUser("senderId")).thenReturn(sender);
-    when(userService.getUser("receiverId")).thenReturn(receiver);
-    when(bookService.getBookById("bookId")).thenReturn(book);
+    when(swapRequestRepository.existsAlready(any(), any(), any())).thenReturn(false);
+    when(userService.getUser("aaaaaaaaaaaaaaaaaaaaaaaa")).thenReturn(sender);
+    when(userService.getUser("bbbbbbbbbbbbbbbbbbbbbbbb")).thenReturn(receiver);
+    when(bookService.getBookById("cccccccccccccccccccccccc")).thenReturn(book);
     assertThrows(IllegalSwapRequestException.class, () -> swapService.createSwapRequest(swapRequest));
   }
 
@@ -181,7 +181,7 @@ class SwapServiceTest {
   @DisplayName("Should throw when offered book is not in swappable books")
   void createSwapRequestThrowsWhenOfferedBookNotSwappable() {
     var sender = User.builder()
-        .id("senderId")
+        .id("aaaaaaaaaaaaaaaaaaaaaaaa")
         .build();
 
     var swapCondition = SwapCondition.builder()
@@ -191,7 +191,7 @@ class SwapServiceTest {
         .build();
 
     var book = Book.builder()
-        .id("bookId")
+        .id("cccccccccccccccccccccccc")
         .swapCondition(swapCondition)
         .build();
 
@@ -204,7 +204,7 @@ class SwapServiceTest {
         .build();
 
     var receiver = User.builder()
-        .id("receiverId")
+        .id("bbbbbbbbbbbbbbbbbbbbbbbb")
         .books(List.of(book))
         .build();
 
@@ -216,10 +216,10 @@ class SwapServiceTest {
         .swapStatus(SwapStatus.PENDING)
         .swapOffer(swapOffer)
         .build();
-    when(swapRequestRepository.existsAlready("senderId", "receiverId", "bookId")).thenReturn(false);
-    when(userService.getUser("senderId")).thenReturn(sender);
-    when(userService.getUser("receiverId")).thenReturn(receiver);
-    when(bookService.getBookById("bookId")).thenReturn(book);
+    when(swapRequestRepository.existsAlready(any(), any(), any())).thenReturn(false);
+    when(userService.getUser("aaaaaaaaaaaaaaaaaaaaaaaa")).thenReturn(sender);
+    when(userService.getUser("bbbbbbbbbbbbbbbbbbbbbbbb")).thenReturn(receiver);
+    when(bookService.getBookById("cccccccccccccccccccccccc")).thenReturn(book);
     when(bookService.getSwappableBookById("offeredBookId")).thenReturn(offeredBook);
     assertThrows(IllegalSwapRequestException.class, () -> swapService.createSwapRequest(swapRequest));
   }
@@ -228,7 +228,7 @@ class SwapServiceTest {
   @DisplayName("Should throw when offered genre is not in swappable genres")
   void createSwapRequestThrowsWhenOfferedGenreNotSwappable() {
     var sender = User.builder()
-        .id("senderId")
+        .id("aaaaaaaaaaaaaaaaaaaaaaaa")
         .build();
 
     var swapCondition = SwapCondition.builder()
@@ -238,7 +238,7 @@ class SwapServiceTest {
         .build();
 
     var book = Book.builder()
-        .id("bookId")
+        .id("cccccccccccccccccccccccc")
         .swapCondition(swapCondition)
         .build();
 
@@ -251,7 +251,7 @@ class SwapServiceTest {
         .build();
 
     var receiver = User.builder()
-        .id("receiverId")
+        .id("bbbbbbbbbbbbbbbbbbbbbbbb")
         .books(List.of(book))
         .build();
 
@@ -263,10 +263,10 @@ class SwapServiceTest {
         .swapStatus(SwapStatus.PENDING)
         .swapOffer(swapOffer)
         .build();
-    when(swapRequestRepository.existsAlready("senderId", "receiverId", "bookId")).thenReturn(false);
-    when(userService.getUser("senderId")).thenReturn(sender);
-    when(userService.getUser("receiverId")).thenReturn(receiver);
-    when(bookService.getBookById("bookId")).thenReturn(book);
+    when(swapRequestRepository.existsAlready(any(), any(), any())).thenReturn(false);
+    when(userService.getUser("aaaaaaaaaaaaaaaaaaaaaaaa")).thenReturn(sender);
+    when(userService.getUser("bbbbbbbbbbbbbbbbbbbbbbbb")).thenReturn(receiver);
+    when(bookService.getBookById("cccccccccccccccccccccccc")).thenReturn(book);
     when(genreService.getGenreById("offeredGenreId")).thenReturn(offeredGenre);
     assertThrows(IllegalSwapRequestException.class, () -> swapService.createSwapRequest(swapRequest));
   }
@@ -275,7 +275,7 @@ class SwapServiceTest {
   @DisplayName("Should create swap request with valid offered book")
   void createSwapRequestWithValidOfferedBook() {
     var sender = User.builder()
-        .id("senderId")
+        .id("aaaaaaaaaaaaaaaaaaaaaaaa")
         .build();
 
     var offeredBook = SwappableBook.builder()
@@ -289,11 +289,11 @@ class SwapServiceTest {
         .build();
 
     var book = Book.builder()
-        .id("bookId")
+        .id("cccccccccccccccccccccccc")
         .language(Language.ENGLISH)
         .condition(Condition.GOOD)
         .swapCondition(swapCondition)
-        .owner(User.builder().id("receiverId").build())
+        .owner(User.builder().id("bbbbbbbbbbbbbbbbbbbbbbbb").build())
         .build();
 
     var swapOffer = SwapOffer.builder()
@@ -301,7 +301,7 @@ class SwapServiceTest {
         .build();
 
     var receiver = User.builder()
-        .id("receiverId")
+        .id("bbbbbbbbbbbbbbbbbbbbbbbb")
         .books(List.of(book))
         .build();
 
@@ -314,25 +314,25 @@ class SwapServiceTest {
         .swapOffer(swapOffer)
         .build();
 
-    when(swapRequestRepository.existsAlready("senderId", "receiverId", "bookId")).thenReturn(false);
+    when(swapRequestRepository.existsAlready(any(), any(), any())).thenReturn(false);
 
-    when(userService.getUser("senderId")).thenReturn(sender);
+    when(userService.getUser("aaaaaaaaaaaaaaaaaaaaaaaa")).thenReturn(sender);
 
-    when(userService.getUser("receiverId")).thenReturn(receiver);
+    when(userService.getUser("bbbbbbbbbbbbbbbbbbbbbbbb")).thenReturn(receiver);
 
-    when(bookService.getBookById("bookId")).thenReturn(book);
+    when(bookService.getBookById("cccccccccccccccccccccccc")).thenReturn(book);
 
     when(bookService.getSwappableBookById("offeredBookId")).thenReturn(offeredBook);
 
     var mockUserDao = mock(UserDao.class);
-    when(mockUserDao.id()).thenReturn("senderId");
+    when(mockUserDao.id()).thenReturn("aaaaaaaaaaaaaaaaaaaaaaaa");
     var mockReceiverDao = mock(UserDao.class);
-    when(mockReceiverDao.id()).thenReturn("receiverId");
+    when(mockReceiverDao.id()).thenReturn("bbbbbbbbbbbbbbbbbbbbbbbb");
     var mockSwapRequestDao = mock(SwapRequestDao.class);
     when(mockSwapRequestDao.sender()).thenReturn(mockUserDao);
     when(mockSwapRequestDao.receiver()).thenReturn(mockReceiverDao);
     var mockBookDao = mock(BookDao.class);
-    when(mockBookDao.id()).thenReturn("bookId");
+    when(mockBookDao.id()).thenReturn("cccccccccccccccccccccccc");
     when(mockSwapRequestDao.bookToSwapWith()).thenReturn(mockBookDao);
     var mockSwapOfferDao = mock(SwapOfferDao.class);
     var mockSwappableBookDao = mock(SwappableBookDao.class);
@@ -367,7 +367,7 @@ class SwapServiceTest {
   @DisplayName("Should create swap request with valid offered genre")
   void createSwapRequestWithValidOfferedGenre() {
     var sender = User.builder()
-        .id("senderId")
+        .id("aaaaaaaaaaaaaaaaaaaaaaaa")
         .build();
 
     var offeredGenre = Genre.builder()
@@ -381,11 +381,11 @@ class SwapServiceTest {
         .build();
 
     var book = Book.builder()
-        .id("bookId")
+        .id("cccccccccccccccccccccccc")
         .language(Language.ENGLISH)
         .condition(Condition.GOOD)
         .swapCondition(swapCondition)
-        .owner(User.builder().id("receiverId").build())
+        .owner(User.builder().id("bbbbbbbbbbbbbbbbbbbbbbbb").build())
         .build();
 
     var swapOffer = SwapOffer.builder()
@@ -393,7 +393,7 @@ class SwapServiceTest {
         .build();
 
     var receiver = User.builder()
-        .id("receiverId")
+        .id("bbbbbbbbbbbbbbbbbbbbbbbb")
         .books(List.of(book))
         .build();
 
@@ -406,20 +406,20 @@ class SwapServiceTest {
         .swapOffer(swapOffer)
         .build();
 
-    when(swapRequestRepository.existsAlready("senderId", "receiverId", "bookId")).thenReturn(false);
-    when(userService.getUser("senderId")).thenReturn(sender);
-    when(userService.getUser("receiverId")).thenReturn(receiver);
-    when(bookService.getBookById("bookId")).thenReturn(book);
+    when(swapRequestRepository.existsAlready(any(), any(), any())).thenReturn(false);
+    when(userService.getUser("aaaaaaaaaaaaaaaaaaaaaaaa")).thenReturn(sender);
+    when(userService.getUser("bbbbbbbbbbbbbbbbbbbbbbbb")).thenReturn(receiver);
+    when(bookService.getBookById("cccccccccccccccccccccccc")).thenReturn(book);
     when(genreService.getGenreById("offeredGenreId")).thenReturn(offeredGenre);
     var mockUserDao2 = mock(UserDao.class);
-    when(mockUserDao2.id()).thenReturn("senderId");
+    when(mockUserDao2.id()).thenReturn("aaaaaaaaaaaaaaaaaaaaaaaa");
     var mockReceiverDao2 = mock(UserDao.class);
-    when(mockReceiverDao2.id()).thenReturn("receiverId");
+    when(mockReceiverDao2.id()).thenReturn("bbbbbbbbbbbbbbbbbbbbbbbb");
     var mockSwapRequestDao2 = mock(SwapRequestDao.class);
     when(mockSwapRequestDao2.sender()).thenReturn(mockUserDao2);
     when(mockSwapRequestDao2.receiver()).thenReturn(mockReceiverDao2);
     var mockBookDao2 = mock(BookDao.class);
-    when(mockBookDao2.id()).thenReturn("bookId");
+    when(mockBookDao2.id()).thenReturn("cccccccccccccccccccccccc");
     when(mockSwapRequestDao2.bookToSwapWith()).thenReturn(mockBookDao2);
     var mockSwapOfferDao2 = mock(SwapOfferDao.class);
     var mockGenreDao2 = mock(GenreDao.class);
@@ -498,7 +498,7 @@ class SwapServiceTest {
     when(mockReceiverDao.id()).thenReturn("receiver123");
 
     // Mock BookDao
-    when(mockBookDao.id()).thenReturn("bookId");
+    when(mockBookDao.id()).thenReturn("cccccccccccccccccccccccc");
     when(mockBookDao.title()).thenReturn("Test Book");
     when(mockBookDao.author()).thenReturn("Test Author");
     when(mockBookDao.description()).thenReturn("Test Description");
@@ -560,7 +560,7 @@ class SwapServiceTest {
     when(mockReceiverDao.id()).thenReturn(userId);
 
     // Mock BookDao
-    when(mockBookDao.id()).thenReturn("bookId");
+    when(mockBookDao.id()).thenReturn("cccccccccccccccccccccccc");
     when(mockBookDao.title()).thenReturn("Test Book");
     when(mockBookDao.author()).thenReturn("Test Author");
     when(mockBookDao.description()).thenReturn("Test Description");
@@ -622,7 +622,7 @@ class SwapServiceTest {
     when(mockReceiverDao.id()).thenReturn(userId);
 
     // Mock BookDao
-    when(mockBookDao.id()).thenReturn("bookId");
+    when(mockBookDao.id()).thenReturn("cccccccccccccccccccccccc");
     when(mockBookDao.title()).thenReturn("Test Book");
     when(mockBookDao.author()).thenReturn("Test Author");
     when(mockBookDao.description()).thenReturn("Test Description");
@@ -685,7 +685,7 @@ class SwapServiceTest {
     when(mockReceiverDao.id()).thenReturn(userId);
 
     // Mock BookDao
-    when(mockBookDao.id()).thenReturn("bookId");
+    when(mockBookDao.id()).thenReturn("cccccccccccccccccccccccc");
     when(mockBookDao.title()).thenReturn("Test Book");
     when(mockBookDao.author()).thenReturn("Test Author");
     when(mockBookDao.description()).thenReturn("Test Description");
@@ -720,8 +720,8 @@ class SwapServiceTest {
   @DisplayName("Should throw IllegalSwapRequestException when sender and receiver are the same")
   void createSwapRequestThrowsWhenSenderAndReceiverAreSame() {
     // Given
-    var user = new User().id("sameUserId");
-    var book = Book.builder().id("bookId").build();
+    var user = new User().id("dddddddddddddddddddddddd");
+    var book = Book.builder().id("cccccccccccccccccccccccc").build();
 
     var swapRequest = SwapRequest.builder()
         .sender(user)
@@ -729,12 +729,12 @@ class SwapServiceTest {
         .bookToSwapWith(book)
         .build();
 
-    when(swapRequestRepository.existsAlready("sameUserId", "sameUserId", "bookId")).thenReturn(false);
+    when(swapRequestRepository.existsAlready(any(), any(), any())).thenReturn(false);
 
     // When & Then
     assertThrows(IllegalSwapRequestException.class,
         () -> swapService.createSwapRequest(swapRequest));
-    verify(swapRequestRepository).existsAlready("sameUserId", "sameUserId", "bookId");
+    verify(swapRequestRepository).existsAlready(any(), any(), any());
   }
 
   @Test
@@ -742,12 +742,12 @@ class SwapServiceTest {
   void createSwapRequestWithoutSwapOfferSuccess() {
     // Given
     var sender = new User()
-        .id("senderId")
+        .id("aaaaaaaaaaaaaaaaaaaaaaaa")
         .firstName("John")
         .lastName("Doe")
         .books(List.of());
 
-    var receiver = new User().id("receiverId");
+    var receiver = new User().id("bbbbbbbbbbbbbbbbbbbbbbbb");
 
     var swapCondition = new SwapCondition()
         .swappableBooks(List.of())
@@ -757,12 +757,12 @@ class SwapServiceTest {
         .openForOffers(false);
 
     var book = Book.builder()
-        .id("bookId")
+        .id("cccccccccccccccccccccccc")
         .title("Test Book")
         .language(Language.ENGLISH)
         .condition(Condition.GOOD)
         .swapCondition(swapCondition)
-        .owner(User.builder().id("receiverId").build())
+        .owner(User.builder().id("bbbbbbbbbbbbbbbbbbbbbbbb").build())
         .build();
 
     receiver.books(List.of(book));
@@ -775,12 +775,13 @@ class SwapServiceTest {
         .swapOffer(null) // No swap offer
         .build();
 
-    when(swapRequestRepository.existsAlready("senderId", "receiverId", "bookId")).thenReturn(false);
-    when(userService.getUser("senderId")).thenReturn(sender);
-    when(userService.getUser("receiverId")).thenReturn(receiver);
-    when(bookService.getBookById("bookId")).thenReturn(book);
+    when(swapRequestRepository.existsAlready(any(), any(), any())).thenReturn(false);
+    when(userService.getUser("aaaaaaaaaaaaaaaaaaaaaaaa")).thenReturn(sender);
+    when(userService.getUser("bbbbbbbbbbbbbbbbbbbbbbbb")).thenReturn(receiver);
+    when(bookService.getBookById("cccccccccccccccccccccccc")).thenReturn(book);
 
-    var mockSwapRequestDao = createMockSwapRequestDao("senderId", "receiverId", "bookId", "Pending", null);
+    var mockSwapRequestDao = createMockSwapRequestDao("aaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbb",
+        "cccccccccccccccccccccccc", "Pending", null);
     when(swapRequestRepository.save(any())).thenReturn(mockSwapRequestDao);
 
     // When
@@ -789,7 +790,7 @@ class SwapServiceTest {
     // Then
     assertNotNull(result);
     verify(swapRequestRepository).save(any());
-    verify(notificationClient).sendNotification(eq("receiverId"), anyString(), anyString());
+    verify(notificationClient).sendNotification(eq("bbbbbbbbbbbbbbbbbbbbbbbb"), anyString(), anyString());
   }
 
   @Test
@@ -797,12 +798,12 @@ class SwapServiceTest {
   void createSwapRequestSendsNotificationOnSuccess() {
     // Given
     var sender = new User()
-        .id("senderId")
+        .id("aaaaaaaaaaaaaaaaaaaaaaaa")
         .firstName("John")
         .lastName("Doe")
         .books(List.of());
 
-    var receiver = new User().id("receiverId");
+    var receiver = new User().id("bbbbbbbbbbbbbbbbbbbbbbbb");
 
     var swapCondition = new SwapCondition()
         .swappableBooks(List.of())
@@ -812,12 +813,12 @@ class SwapServiceTest {
         .openForOffers(false);
 
     var book = Book.builder()
-        .id("bookId")
+        .id("cccccccccccccccccccccccc")
         .title("Amazing Book")
         .language(Language.ENGLISH)
         .condition(Condition.GOOD)
         .swapCondition(swapCondition)
-        .owner(User.builder().id("receiverId").build())
+        .owner(User.builder().id("bbbbbbbbbbbbbbbbbbbbbbbb").build())
         .build();
 
     receiver.books(List.of(book));
@@ -829,12 +830,13 @@ class SwapServiceTest {
         .swapType(SwapType.BY_BOOKS)
         .build();
 
-    when(swapRequestRepository.existsAlready("senderId", "receiverId", "bookId")).thenReturn(false);
-    when(userService.getUser("senderId")).thenReturn(sender);
-    when(userService.getUser("receiverId")).thenReturn(receiver);
-    when(bookService.getBookById("bookId")).thenReturn(book);
+    when(swapRequestRepository.existsAlready(any(), any(), any())).thenReturn(false);
+    when(userService.getUser("aaaaaaaaaaaaaaaaaaaaaaaa")).thenReturn(sender);
+    when(userService.getUser("bbbbbbbbbbbbbbbbbbbbbbbb")).thenReturn(receiver);
+    when(bookService.getBookById("cccccccccccccccccccccccc")).thenReturn(book);
 
-    var mockSwapRequestDao = createMockSwapRequestDao("senderId", "receiverId", "bookId", "Pending", null);
+    var mockSwapRequestDao = createMockSwapRequestDao("aaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbb",
+        "cccccccccccccccccccccccc", "Pending", null);
     when(swapRequestRepository.save(any())).thenReturn(mockSwapRequestDao);
 
     // When
@@ -842,7 +844,7 @@ class SwapServiceTest {
 
     // Then
     verify(notificationClient).sendNotification(
-        eq("receiverId"),
+        eq("bbbbbbbbbbbbbbbbbbbbbbbb"),
         eq("New Swap Request"),
         eq("John Doe wants to swap for your book 'Amazing Book'"));
   }
@@ -853,12 +855,12 @@ class SwapServiceTest {
     // Given
 
     var sender = new User()
-        .id("senderId")
+        .id("aaaaaaaaaaaaaaaaaaaaaaaa")
         .firstName("John")
         .lastName("Doe")
         .books(List.of());
 
-    var receiver = new User().id("receiverId");
+    var receiver = new User().id("bbbbbbbbbbbbbbbbbbbbbbbb");
 
     var swapCondition = new SwapCondition().swappableBooks(List.of())
         .swappableGenres(List.of())
@@ -867,12 +869,12 @@ class SwapServiceTest {
         .openForOffers(false);
 
     var book = Book.builder()
-        .id("bookId")
+        .id("cccccccccccccccccccccccc")
         .title("Test Book")
         .language(Language.ENGLISH)
         .condition(Condition.GOOD)
         .swapCondition(swapCondition)
-        .owner(User.builder().id("receiverId").build())
+        .owner(User.builder().id("bbbbbbbbbbbbbbbbbbbbbbbb").build())
         .build();
 
     receiver.books(List.of(book));
@@ -884,12 +886,13 @@ class SwapServiceTest {
         .swapType(SwapType.BY_BOOKS)
         .build();
 
-    when(swapRequestRepository.existsAlready("senderId", "receiverId", "bookId")).thenReturn(false);
-    when(userService.getUser("senderId")).thenReturn(sender);
-    when(userService.getUser("receiverId")).thenReturn(receiver);
-    when(bookService.getBookById("bookId")).thenReturn(book);
+    when(swapRequestRepository.existsAlready(any(), any(), any())).thenReturn(false);
+    when(userService.getUser("aaaaaaaaaaaaaaaaaaaaaaaa")).thenReturn(sender);
+    when(userService.getUser("bbbbbbbbbbbbbbbbbbbbbbbb")).thenReturn(receiver);
+    when(bookService.getBookById("cccccccccccccccccccccccc")).thenReturn(book);
 
-    var mockSwapRequestDao = createMockSwapRequestDao("senderId", "receiverId", "bookId", "Pending", null);
+    var mockSwapRequestDao = createMockSwapRequestDao("aaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbb",
+        "cccccccccccccccccccccccc", "Pending", null);
     when(swapRequestRepository.save(any())).thenReturn(mockSwapRequestDao);
 
     // Notification service throws exception
@@ -909,7 +912,7 @@ class SwapServiceTest {
     String userId = "receiver123";
     SwapStatus newStatus = SwapStatus.ACCEPTED;
 
-    var mockSwapRequestDao = createMockSwapRequestDao("sender123", userId, "bookId", "Pending", null);
+    var mockSwapRequestDao = createMockSwapRequestDao("sender123", userId, "cccccccccccccccccccccccc", "Pending", null);
     when(mockSwapRequestDao.bookToSwapWith().title()).thenReturn("Amazing Book");
 
     when(swapRequestRepository.findById(swapRequestId)).thenReturn(Optional.of(mockSwapRequestDao));
@@ -933,7 +936,7 @@ class SwapServiceTest {
     String userId = "receiver123";
     SwapStatus newStatus = SwapStatus.REJECTED;
 
-    var mockSwapRequestDao = createMockSwapRequestDao("sender123", userId, "bookId", "Pending", null);
+    var mockSwapRequestDao = createMockSwapRequestDao("sender123", userId, "cccccccccccccccccccccccc", "Pending", null);
 
     when(swapRequestRepository.findById(swapRequestId)).thenReturn(Optional.of(mockSwapRequestDao));
     when(swapRequestRepository.save(any(SwapRequestDao.class))).thenReturn(mockSwapRequestDao);
@@ -955,7 +958,7 @@ class SwapServiceTest {
     String userId = "receiver123";
     SwapStatus newStatus = SwapStatus.ACCEPTED;
 
-    var mockSwapRequestDao = createMockSwapRequestDao("sender123", userId, "bookId", "Pending", null);
+    var mockSwapRequestDao = createMockSwapRequestDao("sender123", userId, "cccccccccccccccccccccccc", "Pending", null);
 
     when(swapRequestRepository.findById(swapRequestId)).thenReturn(Optional.of(mockSwapRequestDao));
     when(swapRequestRepository.save(any(SwapRequestDao.class))).thenReturn(mockSwapRequestDao);
@@ -973,7 +976,7 @@ class SwapServiceTest {
     String userId = "receiver123";
     SwapStatus newStatus = SwapStatus.REJECTED;
 
-    var mockSwapRequestDao = createMockSwapRequestDao("sender123", userId, "bookId", "Pending", null);
+    var mockSwapRequestDao = createMockSwapRequestDao("sender123", userId, "cccccccccccccccccccccccc", "Pending", null);
 
     when(swapRequestRepository.findById(swapRequestId)).thenReturn(Optional.of(mockSwapRequestDao));
     when(swapRequestRepository.save(any(SwapRequestDao.class))).thenReturn(mockSwapRequestDao);
@@ -991,7 +994,8 @@ class SwapServiceTest {
     String userId = "receiver123";
     SwapStatus newStatus = SwapStatus.ACCEPTED;
 
-    var mockSwapRequestDao = createMockSwapRequestDao("sender123", userId, "bookId", "Rejected", null);
+    var mockSwapRequestDao = createMockSwapRequestDao("sender123", userId, "cccccccccccccccccccccccc", "Rejected",
+        null);
 
     when(swapRequestRepository.findById(swapRequestId)).thenReturn(Optional.of(mockSwapRequestDao));
 


### PR DESCRIPTION
## Summary

Implements the backend slice of the pre-launch audit. Five focused commits, all
audit todos applied as patches against `main`.

## Changes by commit

1. **`Fix: harden auth and identity surface for launch`**
   - Gate `GET /users/{id}` behind auth and split response into `PublicUserResponse` (id/firstName/lastName/city/country/aboutMe/favGenres/books) for non-self viewers vs full `UserResponse` for self.
   - Restrict `GET /users` and `GET /admin-users` to admin authorities only.
   - Disable Swagger UI / OpenAPI in `cloud` profile (security `denyAll` + `springdoc.api-docs.enabled=false`).
   - Restrict `POST/PUT/DELETE /genres` and `POST/DELETE /photos/supported-cover-photos` to admin authorities.
   - Forbid admin JWTs on the application WebSocket (closes the impersonation vector where admins could route their connection to any user's STOMP queue via a client-supplied `userId` header).
   - Drop client-supplied `ownerId` from `CreateBookRequest`; owner is taken from `Principal` in `BookController#createBook`.
   - Tie `/change-password/{email}` to authenticated principal + Redis-backed rate limit.
   - Add `/users/logout` that revokes the consumed refresh-token jti.
   - Rotate refresh tokens on `/refresh-token` and revoke the old jti.
   - Add fail-closed rate-limiter variant; use it on login, Google login, refresh, change-password, reset-password, OTP.
   - `/send-otp` returns uniform success regardless of account existence (enumeration mitigation); password-reset tokens are single-use via Redis jti denylist.
   - Magic-byte sniffing in `ValidationUtil`; lower `max-file-size` to 10MB.
   - Move DEBUG log overrides out of shared `application.yaml` into local-only profile.

2. **`Fix: backend correctness around swap, chat, and notifications`**
   - `SwapRequestRepository#existsAlready` filters to active statuses so closed swaps no longer block re-requests.
   - `@Version` on `SwapRequestDao` and `OptimisticLockingFailureException → 409` for concurrent status transitions.
   - Notify the *counterparty* on swap status changes (not always the sender).
   - Block sending chat messages once the swap leaves an active status (history remains readable).
   - Enforce `blockedUserIds` in `SwapService#createSwapRequest` and `ChatService#sendMessage*`.
   - Resolve cover photos to presigned URLs in swap responses via `PhotoService` (no more raw S3 keys).
   - Inject `x-api-key` gRPC metadata on every outbound notification call (the Go server requires it; without this the outbox retries forever with `Unauthenticated`).

3. **`Update: harden runtime and container packaging`**
   - Multi-stage `Dockerfile` (Maven build → eclipse-temurin:25-jre runtime), non-root UID 1001, G1GC, `MaxRAMPercentage=75`.
   - `BackendApplication` refuses to start when `KIRJASWAPPI_PRODUCTION=true` and active profile is not `cloud` (defence-in-depth against accidentally booting with `LocalSecurityConfig`).
   - Cloud profile: `server.shutdown=graceful`, stricter error responses.

4. **`Test: cover hardened auth, swap, and notification contracts`**
   - `NotificationServiceApiKeyTest` locks the `x-api-key` metadata contract (would have caught the silent gRPC auth bug pre-launch).
   - `RateLimiterServiceTest` covers fail-open vs fail-closed on Redis errors.
   - `ProfanityFilterServiceTest`.
   - Updated existing controller/integration tests for the new auth gates, principal-bound ownership, change-password binding, magic-byte upload validation, and uniform `/send-otp`.

5. **`Build: gate releases on tests and add supply-chain workflows`**
   - Replace `mvn ... -DskipTests` on the release path with `mvn -B deploy` so failing tests block the docker publish step.
   - Add CodeQL workflow for Java (`security-and-quality` pack).
   - Expand Dependabot (Maven grouped, Docker, GitHub Actions).

## Test plan

- [x] `mvn -B test` — 713 tests pass locally
- [ ] CI green on this PR (the new release path now actually runs tests)
- [ ] Smoke-test `/api/v1/users/login`, `/api/v1/users/refresh-token`, `/api/v1/swap-requests` flow on a canary deploy
- [ ] Verify gRPC `x-api-key` metadata reaches notification service in canary (search logs for `Unauthenticated` after deploy)
- [ ] Confirm `KIRJASWAPPI_PRODUCTION=true` is set on prod compose so the local-profile guard activates

## Out of scope (deferred to post-launch)

- **H1** httpOnly cookies (multi-file refactor; requires CSRF defense). Mitigations: stopped client-side AES wrapping, `baseQueryWithReauth`, `PrivateRoute` validates session, `/logout` revokes refresh tokens, refresh-token rotation.
- **H3** Split JWT signing keys / migrate to RS256/ES256 with KMS. Mitigations: jti revocation for reset and refresh tokens, fail-closed limits on auth flows.

## Action required outside this PR

- **Rotate `NOTIFICATION_API_KEY`** — the audit identified the previous value as compromised (it was bundled into the SPA via `VITE_NOTIFICATION_API_KEY`).
- Set `KIRJASWAPPI_PRODUCTION=true` on prod compose alongside `SPRING_PROFILES_ACTIVE=cloud` (added to infra repo's docker-compose; double-check it lands).