### PR TITLE
Fix: revert maven Docker image to valid tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ################ Build stage ################
-FROM maven:3.9.9-sapmachine-25 AS builder
+FROM maven:3-sapmachine-25 AS builder
 
 WORKDIR /build
 


### PR DESCRIPTION
## Summary
- `maven:3.9.9-sapmachine-25` does not exist on Docker Hub — reverts to the original `maven:3-sapmachine-25` floating tag

## Test plan
- [ ] E2E pipeline passes (Docker build stage resolves the image)