### PR TITLE
Fix: allow Prometheus actuator scraping in cloud profile

### DIFF
--- a/src/main/java/com/kirjaswappi/backend/common/configs/CloudSecurityConfig.java
+++ b/src/main/java/com/kirjaswappi/backend/common/configs/CloudSecurityConfig.java
@@ -64,7 +64,7 @@ public class CloudSecurityConfig {
         .csrf(csrf -> csrf.disable()) // Disable CSRF protection
         .authorizeHttpRequests(authorize -> authorize
             // =========== PUBLIC — infrastructure ===========
-            .requestMatchers(HEALTH, API_BASE + AUTHENTICATE,
+            .requestMatchers(HEALTH, PROMETHEUS, API_BASE + AUTHENTICATE,
                 API_BASE + AUTHENTICATE + REFRESH, "/ws/**")
             .permitAll()
             // =========== PUBLIC — authentication ===========

--- a/src/main/java/com/kirjaswappi/backend/common/utils/Constants.java
+++ b/src/main/java/com/kirjaswappi/backend/common/utils/Constants.java
@@ -24,6 +24,7 @@ public class Constants {
   public static final String SWAGGER_UI = "/swagger-ui/**";
   public static final String API_DOCS = "/v3/api-docs/**";
   public static final String HEALTH = "/actuator/health";
+  public static final String PROMETHEUS = "/actuator/prometheus";
   public static final String ROLE = "role";
   public static final String CHANGE_PASSWORD = "/change-password";
   public static final String RESET_PASSWORD = "/reset-password";


### PR DESCRIPTION
## Summary
- allow `/actuator/prometheus` in cloud security config so Prometheus can scrape metrics without authentication failures
- add a dedicated `PROMETHEUS` route constant to keep actuator endpoint paths centralized

## Test plan
- [x] `mvn -q -DskipTests compile`
- [ ] Deploy backend image and confirm Prometheus scrape no longer returns 401
- [ ] Confirm backend startup logs no longer contain repeated unauthenticated scrape warnings