### PR TITLE
Fix: skip Unleash client when API key is missing

### DIFF
--- a/src/main/java/com/kirjaswappi/backend/common/configs/FeatureFlagProvider.java
+++ b/src/main/java/com/kirjaswappi/backend/common/configs/FeatureFlagProvider.java
@@ -7,9 +7,12 @@ package com.kirjaswappi.backend.common.configs;
 import jakarta.annotation.PostConstruct;
 
 import io.getunleash.DefaultUnleash;
+import io.getunleash.FakeUnleash;
 import io.getunleash.Unleash;
 import io.getunleash.util.UnleashConfig;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -17,19 +20,27 @@ import org.springframework.stereotype.Component;
 @Component
 @Profile("cloud")
 public class FeatureFlagProvider {
+  private static final Logger logger = LoggerFactory.getLogger(FeatureFlagProvider.class);
+
   @Value("${unleash.instanceId}")
   private String instanceId;
 
   @Value("${unleash.url}")
   private String apiUrl;
 
-  @Value("${unleash.apiKey}")
+  @Value("${unleash.apiKey:}")
   private String apiKey;
 
-  private Unleash unleash;
+  private Unleash unleash = new FakeUnleash();
 
   @PostConstruct
   private void initializeUnleash() {
+    if (apiKey == null || apiKey.isBlank()) {
+      logger.warn(
+          "UNLEASH_API_KEY is empty; using FakeUnleash fallback and skipping remote feature flag polling");
+      return;
+    }
+
     UnleashConfig config = UnleashConfig.builder()
         .appName("Kirjaswappi-backend")
         .instanceId(instanceId)
@@ -37,6 +48,7 @@ public class FeatureFlagProvider {
         .apiKey(apiKey)
         .build();
     this.unleash = new DefaultUnleash(config);
+    logger.info("Initialized Unleash client for {}", apiUrl);
   }
 
   public boolean isFeatureEnabled(String featureName) {

--- a/src/main/resources/application-cloud.yaml
+++ b/src/main/resources/application-cloud.yaml
@@ -52,4 +52,4 @@ cors:
 unleash:
   url: ${UNLEASH_URL}
   instanceId: ${UNLEASH_INSTANCE_ID}
-  apiKey: ${UNLEASH_API_KEY}
+  apiKey: ${UNLEASH_API_KEY:}


### PR DESCRIPTION
## Summary
- use `FakeUnleash` as the default cloud-profile provider when `UNLEASH_API_KEY` is empty or unset
- skip remote Unleash initialization in that case to prevent repeated unauthorized polling/log spam
- keep real Unleash initialization when a key is provided, with explicit startup logging

## Test plan
- [x] `mvn -q -DskipTests compile`
- [ ] Deploy without `UNLEASH_API_KEY` and verify no `/api/client/*` unauthorized spam
- [ ] Deploy with valid backend token and verify normal feature polling continues