### PR TITLE
Update: remove canary origin from CORS allowed origins

### DIFF
--- a/src/main/java/com/kirjaswappi/backend/common/configs/WebSocketConfig.java
+++ b/src/main/java/com/kirjaswappi/backend/common/configs/WebSocketConfig.java
@@ -45,6 +45,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
       config.enableStompBrokerRelay("/topic", "/queue")
           .setRelayHost(relayHost)
           .setRelayPort(relayPort)
+          .setVirtualHost("/")
           .setClientLogin(relayUser)
           .setClientPasscode(relayPass)
           .setSystemLogin(relayUser)
@@ -60,7 +61,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     config.setUserDestinationPrefix("/user");
   }
 
-  @org.springframework.beans.factory.annotation.Value("${FRONTEND_URL:http://localhost:5173,https://canary.kirjaswappi.fi}")
+  @org.springframework.beans.factory.annotation.Value("${FRONTEND_URL:http://localhost:5173,https://kirjaswappi.fi,https://www.kirjaswappi.fi}")
   private String[] allowedOriginPatterns;
 
   @Override

--- a/src/main/resources/application-cloud.yaml
+++ b/src/main/resources/application-cloud.yaml
@@ -47,7 +47,7 @@ jwt:
   expiration: 300000
 
 cors:
-  allowed-origins: ${CORS_ALLOWED_ORIGINS:https://kirjaswappi.fi,https://www.kirjaswappi.fi,https://canary.kirjaswappi.fi}
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:https://kirjaswappi.fi,https://www.kirjaswappi.fi}
 
 unleash:
   url: ${UNLEASH_URL}


### PR DESCRIPTION
Removes `https://canary.kirjaswappi.fi` from the default CORS allowed origins in `application-cloud.yaml`. Only production origins remain.