### PR TITLE
Fix: backend bug sweep

### DIFF
--- a/src/main/java/com/kirjaswappi/backend/common/components/RedisStartupCleaner.java
+++ b/src/main/java/com/kirjaswappi/backend/common/components/RedisStartupCleaner.java
@@ -4,12 +4,17 @@
  */
 package com.kirjaswappi.backend.common.components;
 
+import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -26,10 +31,25 @@ public class RedisStartupCleaner implements ApplicationRunner {
   @Override
   public void run(ApplicationArguments args) throws Exception {
     try (var connection = redisConnectionFactory.getConnection()) {
-      connection.serverCommands().flushAll();
-      logger.info("Redis cache cleared successfully on startup.");
+      clearCacheKeys(connection);
+      logger.info("Redis cache keys cleared successfully on startup.");
     } catch (Exception e) {
       logger.warn("Failed to clear Redis cache on startup: {}", e.getMessage());
+    }
+  }
+
+  private void clearCacheKeys(RedisConnection connection) {
+    List<String> patterns = List.of(
+        "users::*", "books::*", "genres::*", "nested_genres::*", "imageUrls::*", "unreadCounts::*");
+    for (String pattern : patterns) {
+      ScanOptions options = ScanOptions.scanOptions().match(pattern).count(100).build();
+      try (Cursor<byte[]> cursor = connection.keyCommands().scan(options)) {
+        while (cursor.hasNext()) {
+          connection.keyCommands().del(cursor.next());
+        }
+      } catch (Exception e) {
+        logger.warn("Failed to clear cache keys for pattern {}: {}", pattern, e.getMessage());
+      }
     }
   }
 }

--- a/src/main/java/com/kirjaswappi/backend/common/configs/CacheConfig.java
+++ b/src/main/java/com/kirjaswappi/backend/common/configs/CacheConfig.java
@@ -30,7 +30,10 @@ public class CacheConfig {
         long duration = 7;
         TimeUnit unit = TimeUnit.DAYS;
 
-        if (name.equals("unreadCounts")) {
+        if (name.equals("imageUrls")) {
+          duration = 6;
+          unit = TimeUnit.DAYS;
+        } else if (name.equals("unreadCounts")) {
           duration = 5;
           unit = TimeUnit.MINUTES;
         } else if (name.equals("users") || name.equals("books")) {

--- a/src/main/java/com/kirjaswappi/backend/common/configs/MongoIndexConfig.java
+++ b/src/main/java/com/kirjaswappi/backend/common/configs/MongoIndexConfig.java
@@ -98,8 +98,8 @@ public class MongoIndexConfig {
       // Create compound index for latitude and longitude as fallback
       createLocationIndexes();
 
-      // Create text indexes for city and country for faster text searches
-      createTextIndexes();
+      // Create btree indexes for city and country for faster prefix searches
+      createCityCountryIndexes();
 
       logger.info("Successfully created all MongoDB indexes");
 
@@ -161,9 +161,10 @@ public class MongoIndexConfig {
   }
 
   /**
-   * Creates text indexes for city and country searches.
+   * Creates btree indexes for city and country fields to support fast
+   * prefix-anchored searches.
    */
-  private void createTextIndexes() {
+  private void createCityCountryIndexes() {
     try {
       Index cityIndex = new Index()
           .on("location.city", org.springframework.data.domain.Sort.Direction.ASC)
@@ -175,9 +176,9 @@ public class MongoIndexConfig {
           .named("book_location_country");
       mongoTemplate.indexOps(BookDao.class).createIndex(countryIndex);
 
-      logger.debug("Created text indexes for city and country searches");
+      logger.debug("Created btree indexes for city and country searches");
     } catch (Exception e) {
-      logger.warn("Failed to create text indexes: {}", e.getMessage());
+      logger.warn("Failed to create city/country indexes: {}", e.getMessage());
     }
   }
 

--- a/src/main/java/com/kirjaswappi/backend/common/jpa/daos/OTPDao.java
+++ b/src/main/java/com/kirjaswappi/backend/common/jpa/daos/OTPDao.java
@@ -11,6 +11,8 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.Accessors;
 
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Document(collection = "otp")
@@ -21,12 +23,17 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @NoArgsConstructor
 @AllArgsConstructor
 public class OTPDao {
+  @Id
+  private String id;
+
   @NotNull
+  @Indexed(unique = true)
   private String email;
 
   @NotNull
   private String otp;
 
   @NotNull
+  @Indexed(expireAfterSeconds = 1200)
   private Instant createdAt;
 }

--- a/src/main/java/com/kirjaswappi/backend/common/migrations/AddSwapRequestUniqueIndex.java
+++ b/src/main/java/com/kirjaswappi/backend/common/migrations/AddSwapRequestUniqueIndex.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 KirjaSwappi or KirjaSwappi affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+package com.kirjaswappi.backend.common.migrations;
+
+import java.util.List;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+@ChangeUnit(id = "add-swap-request-unique-index", order = "005", author = "mahiuddinalkamal")
+public class AddSwapRequestUniqueIndex {
+
+  private final MongoTemplate mongoTemplate;
+
+  public AddSwapRequestUniqueIndex(MongoTemplate mongoTemplate) {
+    this.mongoTemplate = mongoTemplate;
+  }
+
+  @Execution
+  public void executeMigration() {
+    mongoTemplate.execute("swap_requests", collection -> {
+      org.bson.Document keys = new org.bson.Document("sender.$id", 1)
+          .append("receiver.$id", 1)
+          .append("bookToSwapWith.$id", 1);
+
+      org.bson.Document partialFilter = new org.bson.Document("swapStatus",
+          new org.bson.Document("$in", List.of("Pending", "Accepted", "Reserved")));
+
+      com.mongodb.client.model.IndexOptions options = new com.mongodb.client.model.IndexOptions()
+          .unique(true)
+          .partialFilterExpression(partialFilter)
+          .name("swap_request_active_unique_idx");
+
+      collection.createIndex(keys, options);
+      return null;
+    });
+  }
+
+  @RollbackExecution
+  public void rollbackMigration() {
+    mongoTemplate.indexOps("swap_requests").dropIndex("swap_request_active_unique_idx");
+  }
+}

--- a/src/main/java/com/kirjaswappi/backend/common/service/NotificationService.java
+++ b/src/main/java/com/kirjaswappi/backend/common/service/NotificationService.java
@@ -145,14 +145,17 @@ public class NotificationService implements NotificationClient {
     // instances.
     Query query = new Query(Criteria.where("status").is(STATUS_PENDING))
         .with(org.springframework.data.domain.Sort.by("createdAt"));
-    Update update = new Update()
-        .set("status", STATUS_PROCESSING)
-        .set("claimedAt", Instant.now());
     FindAndModifyOptions options = FindAndModifyOptions.options().returnNew(true);
 
     NotificationOutboxDao notification;
-    while ((notification = mongoTemplate.findAndModify(query, update, options,
-        NotificationOutboxDao.class)) != null) {
+    while (true) {
+      // Rebuild update each iteration so claimedAt records the actual claim time
+      Update update = new Update()
+          .set("status", STATUS_PROCESSING)
+          .set("claimedAt", Instant.now());
+      notification = mongoTemplate.findAndModify(query, update, options, NotificationOutboxDao.class);
+      if (notification == null)
+        break;
       processNotification(notification);
     }
   }

--- a/src/main/java/com/kirjaswappi/backend/common/service/NotificationService.java
+++ b/src/main/java/com/kirjaswappi/backend/common/service/NotificationService.java
@@ -6,7 +6,6 @@ package com.kirjaswappi.backend.common.service;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import io.grpc.CallCredentials;
@@ -19,6 +18,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.mongodb.core.FindAndModifyOptions;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -34,15 +38,20 @@ public class NotificationService implements NotificationClient {
   private static final Logger logger = LoggerFactory.getLogger(NotificationService.class);
 
   private static final String STATUS_PENDING = "PENDING";
+  private static final String STATUS_PROCESSING = "PROCESSING";
   private static final String STATUS_SENT = "SENT";
   private static final String STATUS_FAILED = "FAILED";
   private static final int MAX_RETRIES = 3;
   private static final Duration FAILED_RETENTION = Duration.ofDays(7);
   private static final Duration SENT_RETENTION = Duration.ofDays(14);
+  private static final Duration PROCESSING_TIMEOUT = Duration.ofMinutes(5);
   private static final long CLEANUP_INTERVAL_MS = 86_400_000L; // 1 day
 
   @Autowired
   private NotificationOutboxRepository notificationOutboxRepository;
+
+  @Autowired
+  private MongoTemplate mongoTemplate;
 
   private static final Metadata.Key<String> API_KEY_METADATA_KEY = Metadata.Key.of("x-api-key",
       Metadata.ASCII_STRING_MARSHALLER);
@@ -132,15 +141,18 @@ public class NotificationService implements NotificationClient {
       return;
     }
 
-    List<NotificationOutboxDao> pendingNotifications = notificationOutboxRepository
-        .findByStatusOrderByCreatedAtAsc(STATUS_PENDING);
-    if (pendingNotifications.isEmpty()) {
-      return;
-    }
+    // Atomically claim one PENDING doc at a time to prevent duplicate sends across
+    // instances.
+    Query query = new Query(Criteria.where("status").is(STATUS_PENDING))
+        .with(org.springframework.data.domain.Sort.by("createdAt"));
+    Update update = new Update()
+        .set("status", STATUS_PROCESSING)
+        .set("claimedAt", Instant.now());
+    FindAndModifyOptions options = FindAndModifyOptions.options().returnNew(true);
 
-    logger.debug("Processing {} pending notifications", pendingNotifications.size());
-
-    for (NotificationOutboxDao notification : pendingNotifications) {
+    NotificationOutboxDao notification;
+    while ((notification = mongoTemplate.findAndModify(query, update, options,
+        NotificationOutboxDao.class)) != null) {
       processNotification(notification);
     }
   }
@@ -182,7 +194,7 @@ public class NotificationService implements NotificationClient {
       logger.error("Notification failed permanently for user: {}. Error: {}", notification.userId(), error);
     } else {
       notification.retryCount(notification.retryCount() + 1);
-      // Keep status PENDING to try again
+      notification.status(STATUS_PENDING);
       logger.warn("Notification failed for user: {}. Retrying ({}/{}). Error: {}",
           notification.userId(), notification.retryCount(), MAX_RETRIES, error);
     }
@@ -193,6 +205,16 @@ public class NotificationService implements NotificationClient {
   public void cleanupFailedNotifications() {
     if (!enabled) {
       return;
+    }
+
+    // Crash recovery: reset stale PROCESSING docs back to PENDING.
+    Instant processingCutoff = Instant.now().minus(PROCESSING_TIMEOUT);
+    Query staleQuery = new Query(Criteria.where("status").is(STATUS_PROCESSING)
+        .and("claimedAt").lt(processingCutoff));
+    Update resetUpdate = new Update().set("status", STATUS_PENDING).unset("claimedAt");
+    var resetResult = mongoTemplate.updateMulti(staleQuery, resetUpdate, NotificationOutboxDao.class);
+    if (resetResult.getModifiedCount() > 0) {
+      logger.info("Reset {} stale PROCESSING notifications back to PENDING", resetResult.getModifiedCount());
     }
 
     Instant failedCutoff = Instant.now().minus(FAILED_RETENTION);

--- a/src/main/java/com/kirjaswappi/backend/http/controllers/ChatController.java
+++ b/src/main/java/com/kirjaswappi/backend/http/controllers/ChatController.java
@@ -8,6 +8,7 @@ import static com.kirjaswappi.backend.common.utils.Constants.*;
 
 import java.security.Principal;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import jakarta.validation.Valid;
 
@@ -61,11 +62,11 @@ public class ChatController {
     // Create swap context
     ChatMessageResponse.SwapContextResponse swapContext = createSwapContext(swapRequest);
 
-    List<ChatMessageResponse> response = messages.stream()
-        .map(message -> {
-          ChatMessageResponse chatResponse = new ChatMessageResponse(message, userId);
+    List<ChatMessageResponse> response = IntStream.range(0, messages.size())
+        .mapToObj(i -> {
+          ChatMessageResponse chatResponse = new ChatMessageResponse(messages.get(i), userId);
           // Include swap context only in the first message for efficiency
-          if (messages.indexOf(message) == 0) {
+          if (i == 0) {
             chatResponse.setSwapContext(swapContext);
           }
           return chatResponse;

--- a/src/main/java/com/kirjaswappi/backend/jpa/daos/NotificationOutboxDao.java
+++ b/src/main/java/com/kirjaswappi/backend/jpa/daos/NotificationOutboxDao.java
@@ -48,5 +48,8 @@ public class NotificationOutboxDao {
   private Instant sentAt;
 
   @Nullable
+  private Instant claimedAt;
+
+  @Nullable
   private String errorMessage;
 }

--- a/src/main/java/com/kirjaswappi/backend/jpa/daos/UserDao.java
+++ b/src/main/java/com/kirjaswappi/backend/jpa/daos/UserDao.java
@@ -12,6 +12,7 @@ import lombok.*;
 import lombok.experimental.Accessors;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Version;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.DBRef;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -28,6 +29,9 @@ import com.mongodb.lang.Nullable;
 public class UserDao {
   @Id
   private String id;
+
+  @Version
+  private Long version;
 
   @NotNull
   private String firstName;

--- a/src/main/java/com/kirjaswappi/backend/service/BookService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/BookService.java
@@ -341,8 +341,12 @@ public class BookService {
   }
 
   private SwappableBook swappableBookWithImageUrl(SwappableBookDao bookDao) {
-    var coverPhotoImageUrl = photoService.getBookCoverPhoto(bookDao.coverPhoto());
-    return SwappableBookMapper.toEntity(bookDao, coverPhotoImageUrl);
+    if (bookDao.coverPhoto() != null) {
+      var coverPhotoImageUrl = photoService.getBookCoverPhoto(bookDao.coverPhoto());
+      return SwappableBookMapper.toEntity(bookDao, coverPhotoImageUrl);
+    } else {
+      return SwappableBookMapper.toEntity(bookDao);
+    }
   }
 
   @NotNull

--- a/src/main/java/com/kirjaswappi/backend/service/InboxService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/InboxService.java
@@ -47,14 +47,15 @@ public class InboxService {
     List<SwapRequestDao> allSwapRequestDaos = new ArrayList<>();
 
     if (status != null && !status.trim().isEmpty()) {
-      // Validate status
-      SwapStatus.fromCode(status); // This will throw BadRequestException if invalid
+      // Parse once — validates and normalises to canonical code (e.g. "accepted" →
+      // "Accepted")
+      String normalizedStatus = SwapStatus.fromCode(status).getCode();
 
       // Get both sent and received with status filter
       List<SwapRequestDao> receivedDaos = swapRequestRepository
-          .findByReceiverIdAndSwapStatusOrderByRequestedAtDesc(userId, SwapStatus.fromCode(status).getCode());
+          .findByReceiverIdAndSwapStatusOrderByRequestedAtDesc(userId, normalizedStatus);
       List<SwapRequestDao> sentDaos = swapRequestRepository.findBySenderIdAndSwapStatusOrderByRequestedAtDesc(userId,
-          SwapStatus.fromCode(status).getCode());
+          normalizedStatus);
 
       allSwapRequestDaos.addAll(receivedDaos);
       allSwapRequestDaos.addAll(sentDaos);

--- a/src/main/java/com/kirjaswappi/backend/service/InboxService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/InboxService.java
@@ -52,9 +52,9 @@ public class InboxService {
 
       // Get both sent and received with status filter
       List<SwapRequestDao> receivedDaos = swapRequestRepository
-          .findByReceiverIdAndSwapStatusOrderByRequestedAtDesc(userId, status);
+          .findByReceiverIdAndSwapStatusOrderByRequestedAtDesc(userId, SwapStatus.fromCode(status).getCode());
       List<SwapRequestDao> sentDaos = swapRequestRepository.findBySenderIdAndSwapStatusOrderByRequestedAtDesc(userId,
-          status);
+          SwapStatus.fromCode(status).getCode());
 
       allSwapRequestDaos.addAll(receivedDaos);
       allSwapRequestDaos.addAll(sentDaos);

--- a/src/main/java/com/kirjaswappi/backend/service/SwapService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/SwapService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.bson.types.ObjectId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +25,7 @@ import com.kirjaswappi.backend.jpa.repositories.UserRepository;
 import com.kirjaswappi.backend.mapper.SwapRequestMapper;
 import com.kirjaswappi.backend.service.entities.*;
 import com.kirjaswappi.backend.service.enums.SwapStatus;
+import com.kirjaswappi.backend.service.exceptions.BadRequestException;
 import com.kirjaswappi.backend.service.exceptions.IllegalSwapRequestException;
 import com.kirjaswappi.backend.service.exceptions.InvalidStatusTransitionException;
 import com.kirjaswappi.backend.service.exceptions.SwapRequestExistsAlreadyException;
@@ -50,6 +52,11 @@ public class SwapService {
   private final PhotoService photoService;
 
   public SwapRequest createSwapRequest(SwapRequest swapRequest) {
+    // validate ObjectId formats before use
+    validateObjectId(swapRequest.sender().id());
+    validateObjectId(swapRequest.receiver().id());
+    validateObjectId(swapRequest.bookToSwapWith().id());
+
     // validation: check if the swap request exists already for this book
     if (swapRequestRepository.existsAlready(new ObjectId(swapRequest.sender().id()),
         new ObjectId(swapRequest.receiver().id()), new ObjectId(swapRequest.bookToSwapWith().id()))) {
@@ -123,7 +130,12 @@ public class SwapService {
         .withSwapStatus(SwapStatus.PENDING);
 
     SwapRequestDao dao = SwapRequestMapper.toDao(updatedSwapRequest);
-    SwapRequestDao createdDao = swapRequestRepository.save(dao);
+    SwapRequestDao createdDao;
+    try {
+      createdDao = swapRequestRepository.save(dao);
+    } catch (DuplicateKeyException e) {
+      throw new SwapRequestExistsAlreadyException();
+    }
 
     // Send notification to receiver about new swap request
     try {
@@ -205,6 +217,12 @@ public class SwapService {
     }
 
     return resolveCoverPhotoUrls(SwapRequestMapper.toEntity(updatedDao));
+  }
+
+  private void validateObjectId(String id) {
+    if (!ObjectId.isValid(id)) {
+      throw new BadRequestException("invalidId", id);
+    }
   }
 
   /**

--- a/src/main/java/com/kirjaswappi/backend/service/UserService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/UserService.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -49,6 +50,8 @@ public class UserService {
   private final SwapRequestRepository swapRequestRepository;
 
   private final EmailService emailService;
+
+  private final CacheManager cacheManager;
 
   public User addUser(User user) {
 
@@ -259,7 +262,9 @@ public class UserService {
     dao.salt(newSalt);
     dao.password(newPasswordWithNewSalt);
     userRepository.save(dao);
-    clearUserCache(dao.id());
+    // Evict via CacheManager directly — self-invocation bypasses Spring's AOP proxy
+    // so @CacheEvict on a helper method in the same bean would not fire.
+    cacheManager.getCache("users").evictIfPresent(dao.id());
 
     emailService.sendPasswordChangeConfirmation(dao.email());
 

--- a/src/main/java/com/kirjaswappi/backend/service/UserService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/UserService.java
@@ -243,10 +243,11 @@ public class UserService {
       throw new BadRequestException("userExistsButNotVerified", user.email());
     }
 
-    // forbid newPassword to be the same as currentPassword:
+    // forbid newPassword to be the same as currentPassword (skip for OAuth accounts
+    // with no password):
     String currentPassword = dao.password();
     String newPassword = Util.hashPassword(user.password(), dao.salt());
-    if (currentPassword.equals(newPassword)) {
+    if (currentPassword != null && currentPassword.equals(newPassword)) {
       throw new BadRequestException("newPasswordCannotBeSameAsCurrentPassword", user.email());
     }
 
@@ -258,6 +259,7 @@ public class UserService {
     dao.salt(newSalt);
     dao.password(newPasswordWithNewSalt);
     userRepository.save(dao);
+    clearUserCache(dao.id());
 
     emailService.sendPasswordChangeConfirmation(dao.email());
 
@@ -303,7 +305,7 @@ public class UserService {
     if (userDao.favBooks() != null)
       userDao.favBooks().add(favBookDao);
     else
-      userDao.favBooks(List.of(favBookDao));
+      userDao.favBooks(new ArrayList<>(List.of(favBookDao)));
 
     userRepository.save(userDao);
     return getUser(user.id());
@@ -379,6 +381,11 @@ public class UserService {
       dao.mutedUserIds(mutedIds);
       userRepository.save(dao);
     }
+  }
+
+  @CacheEvict(value = "users", key = "#userId")
+  public void clearUserCache(String userId) {
+    // cache eviction handled by annotation
   }
 
   public User findOrCreateGoogleUser(String email, String firstName, String lastName, String googleSub) {

--- a/src/main/java/com/kirjaswappi/backend/service/filters/FindAllBooksFilter.java
+++ b/src/main/java/com/kirjaswappi/backend/service/filters/FindAllBooksFilter.java
@@ -167,7 +167,9 @@ public class FindAllBooksFilter {
 
     // Filter by city if provided:
     if (city != null && !city.isEmpty()) {
-      combinedCriteria.add(Criteria.where("location.city").regex(java.util.regex.Pattern.quote(city), "i"));
+      combinedCriteria.add(Criteria.where("location.city")
+          .regex(java.util.regex.Pattern.compile("^" + java.util.regex.Pattern.quote(city),
+              java.util.regex.Pattern.CASE_INSENSITIVE)));
     }
 
     // Filter by country if provided:

--- a/src/main/resources/application-cloud.yaml
+++ b/src/main/resources/application-cloud.yaml
@@ -17,6 +17,7 @@ spring:
   lifecycle:
     timeout-per-shutdown-phase: 30s
   rabbitmq:
+    host: ${RABBITMQ_HOST}
     username: ${RABBITMQ_USERNAME}
     password: ${RABBITMQ_PASSWORD}
 

--- a/src/test/java/com/kirjaswappi/backend/common/service/NotificationServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/common/service/NotificationServiceTest.java
@@ -9,7 +9,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import java.time.Instant;
-import java.util.List;
 
 import io.grpc.ManagedChannel;
 
@@ -31,6 +30,9 @@ class NotificationServiceTest {
   private NotificationOutboxRepository notificationOutboxRepository;
 
   @Mock
+  private org.springframework.data.mongodb.core.MongoTemplate mongoTemplate;
+
+  @Mock
   private ManagedChannel channel;
 
   @Mock
@@ -47,6 +49,7 @@ class NotificationServiceTest {
     // Inject mocks using ReflectionTestUtils since they are not injected by
     // constructor
     ReflectionTestUtils.setField(notificationService, "notificationOutboxRepository", notificationOutboxRepository);
+    ReflectionTestUtils.setField(notificationService, "mongoTemplate", mongoTemplate);
     ReflectionTestUtils.setField(notificationService, "channel", channel);
     ReflectionTestUtils.setField(notificationService, "stub", stub);
   }
@@ -71,13 +74,16 @@ class NotificationServiceTest {
         .userId("user1")
         .title("Title")
         .message("Message")
-        .status("PENDING")
+        .status("PROCESSING")
         .retryCount(0)
         .createdAt(Instant.now())
         .build();
 
-    when(notificationOutboxRepository.findByStatusOrderByCreatedAtAsc("PENDING"))
-        .thenReturn(List.of(pendingNotification));
+    // First call returns the claimed notification, second call returns null (no
+    // more)
+    when(mongoTemplate.findAndModify(any(), any(), any(), eq(NotificationOutboxDao.class)))
+        .thenReturn(pendingNotification)
+        .thenReturn(null);
 
     NotificationResponse successResponse = NotificationResponse.newBuilder()
         .setSuccess(true)
@@ -102,13 +108,14 @@ class NotificationServiceTest {
         .userId("user1")
         .title("Title")
         .message("Message")
-        .status("PENDING")
+        .status("PROCESSING")
         .retryCount(0)
         .createdAt(Instant.now())
         .build();
 
-    when(notificationOutboxRepository.findByStatusOrderByCreatedAtAsc("PENDING"))
-        .thenReturn(List.of(pendingNotification));
+    when(mongoTemplate.findAndModify(any(), any(), any(), eq(NotificationOutboxDao.class)))
+        .thenReturn(pendingNotification)
+        .thenReturn(null);
 
     when(stub.sendNotification(any())).thenThrow(new RuntimeException("gRPC Error"));
 
@@ -131,13 +138,14 @@ class NotificationServiceTest {
         .userId("user1")
         .title("Title")
         .message("Message")
-        .status("PENDING")
+        .status("PROCESSING")
         .retryCount(3) // Already at max retries (assuming max=3 check is >=)
         .createdAt(Instant.now())
         .build();
 
-    when(notificationOutboxRepository.findByStatusOrderByCreatedAtAsc("PENDING"))
-        .thenReturn(List.of(pendingNotification));
+    when(mongoTemplate.findAndModify(any(), any(), any(), eq(NotificationOutboxDao.class)))
+        .thenReturn(pendingNotification)
+        .thenReturn(null);
 
     when(stub.sendNotification(any())).thenThrow(new RuntimeException("gRPC Error"));
 
@@ -153,6 +161,8 @@ class NotificationServiceTest {
   @DisplayName("Should delete FAILED notifications older than retention period when enabled")
   void shouldCleanupOldFailedNotificationsWhenEnabled() {
     // Given
+    when(mongoTemplate.updateMulti(any(), any(), eq(NotificationOutboxDao.class)))
+        .thenReturn(com.mongodb.client.result.UpdateResult.acknowledged(0, 0L, null));
     when(notificationOutboxRepository.deleteByStatusAndCreatedAtBefore(eq("FAILED"), any(Instant.class)))
         .thenReturn(3L);
 

--- a/src/test/java/com/kirjaswappi/backend/common/service/OTPServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/common/service/OTPServiceTest.java
@@ -57,7 +57,7 @@ class OTPServiceTest {
   @Test
   @DisplayName("Should throw exception when OTP does not match")
   void verifyOTPThrowsOnInvalid() {
-    OTPDao dao = new OTPDao(email, "654321", Instant.now());
+    OTPDao dao = OTPDao.builder().email(email).otp("654321").createdAt(Instant.now()).build();
     when(otpRepository.findByEmail(email)).thenReturn(Optional.of(dao));
     assertThrows(BadRequestException.class, () -> otpService.verifyOTPByEmail(otp));
   }
@@ -65,7 +65,8 @@ class OTPServiceTest {
   @Test
   @DisplayName("Should throw exception when OTP is expired")
   void verifyOTPThrowsOnExpired() {
-    OTPDao dao = new OTPDao(email, otpValue, Instant.now().minus(Duration.ofMinutes(16)));
+    OTPDao dao = OTPDao.builder().email(email).otp(otpValue).createdAt(Instant.now().minus(Duration.ofMinutes(16)))
+        .build();
     when(otpRepository.findByEmail(email)).thenReturn(Optional.of(dao));
     assertThrows(BadRequestException.class, () -> otpService.verifyOTPByEmail(otp));
   }
@@ -73,7 +74,7 @@ class OTPServiceTest {
   @Test
   @DisplayName("Should verify OTP successfully")
   void verifyOTPSuccess() {
-    OTPDao dao = new OTPDao(email, otpValue, Instant.now());
+    OTPDao dao = OTPDao.builder().email(email).otp(otpValue).createdAt(Instant.now()).build();
     when(otpRepository.findByEmail(email)).thenReturn(Optional.of(dao));
     doNothing().when(otpRepository).deleteAllByEmail(email);
     assertEquals(email, otpService.verifyOTPByEmail(otp));
@@ -118,7 +119,7 @@ class OTPServiceTest {
   void saveAndSendOTPThrowsWhenEmailServiceFails() throws Exception {
     when(userService.checkIfUserExists(email)).thenReturn(true);
     doNothing().when(otpRepository).deleteAllByEmail(email);
-    OTPDao dao = new OTPDao(email, otpValue, Instant.now());
+    OTPDao dao = OTPDao.builder().email(email).otp(otpValue).createdAt(Instant.now()).build();
     when(otpRepository.save(any(OTPDao.class))).thenReturn(dao);
     doThrow(new RuntimeException("email fail")).when(emailService).sendOTPByEmail(any(), any());
     assertThrows(RuntimeException.class, () -> otpService.saveAndSendOTP(email));
@@ -141,7 +142,7 @@ class OTPServiceTest {
   void saveAndSendOTPSuccess() throws Exception {
     when(userService.checkIfUserExists(email)).thenReturn(true);
     doNothing().when(otpRepository).deleteAllByEmail(email);
-    OTPDao dao = new OTPDao(email, otpValue, Instant.now());
+    OTPDao dao = OTPDao.builder().email(email).otp(otpValue).createdAt(Instant.now()).build();
     when(otpRepository.save(any(OTPDao.class))).thenReturn(dao);
     doNothing().when(emailService).sendOTPByEmail(anyString(), anyString());
     assertEquals(email, otpService.saveAndSendOTP(email));

--- a/src/test/java/com/kirjaswappi/backend/service/InboxServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/service/InboxServiceTest.java
@@ -896,4 +896,27 @@ class InboxServiceTest {
     verify(userService).getUser("sender123");
     verify(swapRequestRepository).findById("nonexistent");
   }
+
+  @Test
+  @DisplayName("Lowercase status string should return same results as canonical-case (M2 fix)")
+  void shouldAcceptLowercaseStatusFilter() {
+    // Given
+    when(userService.getUser("receiver123")).thenReturn(userEntity);
+    when(swapRequestRepository.findByReceiverIdAndSwapStatusOrderByRequestedAtDesc("receiver123",
+        SwapStatus.PENDING.getCode()))
+            .thenReturn(List.of(receivedSwapRequest));
+    when(swapRequestRepository.findBySenderIdAndSwapStatusOrderByRequestedAtDesc("receiver123",
+        SwapStatus.PENDING.getCode()))
+            .thenReturn(List.of());
+
+    // When — pass lowercase "pending"; the fix normalises it to "Pending" via
+    // SwapStatus.fromCode
+    List<SwapRequest> result = inboxService.getUnifiedInbox("receiver123", "pending", null);
+
+    // Then
+    assertEquals(1, result.size());
+    assertEquals("received1", result.getFirst().id());
+    verify(swapRequestRepository).findByReceiverIdAndSwapStatusOrderByRequestedAtDesc(
+        "receiver123", SwapStatus.PENDING.getCode());
+  }
 }

--- a/src/test/java/com/kirjaswappi/backend/service/UserServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/service/UserServiceTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.cache.CacheManager;
 
 import com.kirjaswappi.backend.common.service.EmailService;
 import com.kirjaswappi.backend.jpa.daos.BookDao;
@@ -49,6 +50,10 @@ class UserServiceTest {
   private SwapRequestRepository swapRequestRepository;
   @Mock
   private EmailService emailService;
+  @Mock
+  private PhotoService photoService;
+  @Mock
+  private CacheManager cacheManager;
   @InjectMocks
   private UserService userService;
 
@@ -361,6 +366,8 @@ class UserServiceTest {
     when(userRepository.findByEmail("google@example.com")).thenReturn(Optional.of(dao));
     when(userRepository.save(any())).thenReturn(dao);
     doNothing().when(emailService).sendPasswordChangeConfirmation(any());
+    org.springframework.cache.Cache mockCache = mock(org.springframework.cache.Cache.class);
+    when(cacheManager.getCache("users")).thenReturn(mockCache);
 
     assertDoesNotThrow(
         () -> userService.changePassword(new User().email("google@example.com").password("newPass")));

--- a/src/test/java/com/kirjaswappi/backend/service/UserServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/service/UserServiceTest.java
@@ -343,4 +343,66 @@ class UserServiceTest {
     assertEquals(firstName, result.firstName());
     assertEquals(lastName, result.lastName());
   }
+
+  @Test
+  @DisplayName("Should not throw NPE in changePassword when account has no stored password (Google/OAuth)")
+  void changePasswordNoNpeForOAuthAccount() {
+    // Google accounts have no stored password; use a real BCrypt salt so
+    // hashPassword doesn't throw
+    String realSalt = org.springframework.security.crypto.bcrypt.BCrypt.gensalt();
+    UserDao dao = UserDao.builder()
+        .id("oauthId")
+        .email("google@example.com")
+        .password(null)
+        .salt(realSalt)
+        .isEmailVerified(true)
+        .build();
+
+    when(userRepository.findByEmail("google@example.com")).thenReturn(Optional.of(dao));
+    when(userRepository.save(any())).thenReturn(dao);
+    doNothing().when(emailService).sendPasswordChangeConfirmation(any());
+
+    assertDoesNotThrow(
+        () -> userService.changePassword(new User().email("google@example.com").password("newPass")));
+  }
+
+  @Test
+  @DisplayName("Should not throw UnsupportedOperationException when addFavouriteBook called with null favBooks")
+  void addFavouriteBookMutableListWhenFavBooksNull() {
+    UserDao ownerDao = UserDao.builder().id("other").build();
+    BookDao bookDao = BookDao.builder()
+        .id("bookId")
+        .owner(ownerDao)
+        .language("English")
+        .condition("New")
+        .genres(List.of(GenreDao.builder().id("genreId").name("Genre Name").build()))
+        .build();
+
+    UserDao userDao = UserDao.builder().id("id").favBooks(null).build();
+    when(userRepository.findByIdAndIsEmailVerifiedTrue("id")).thenReturn(Optional.of(userDao));
+    when(bookRepository.findByIdAndIsDeletedFalse("bookId")).thenReturn(Optional.of(bookDao));
+    when(userRepository.save(any())).thenReturn(userDao);
+
+    Book favBook = Book.builder().id("bookId").language(Language.ENGLISH).condition(Condition.NEW)
+        .genres(List.of(new Genre("genreId", "Genre Name", null))).build();
+    User user = new User().id("id").favBooks(List.of(favBook));
+
+    // First add — must not throw UnsupportedOperationException
+    assertDoesNotThrow(() -> userService.addFavouriteBook(user));
+
+    // Second add of a different book — list must remain mutable
+    BookDao bookDao2 = BookDao.builder()
+        .id("bookId2")
+        .owner(ownerDao)
+        .language("English")
+        .condition("New")
+        .genres(List.of(GenreDao.builder().id("genreId").name("Genre Name").build()))
+        .build();
+    when(bookRepository.findByIdAndIsDeletedFalse("bookId2")).thenReturn(Optional.of(bookDao2));
+    Book favBook2 = Book.builder().id("bookId2").language(Language.ENGLISH).condition(Condition.NEW)
+        .genres(List.of(new Genre("genreId", "Genre Name", null))).build();
+    User user2 = new User().id("id").favBooks(List.of(favBook2));
+
+    assertDoesNotThrow(() -> userService.addFavouriteBook(user2));
+  }
 }


### PR DESCRIPTION
Fixes the following findings from the parallel bug review:

- H1: RedisStartupCleaner flushAll → scoped cache-key deletion (preserves jwt:* and rate-limit keys)
- H2: Notification outbox poller — atomic findAndModify claim to prevent duplicate sends across instances
- H3: changePassword NPE for Google/OAuth accounts with null stored password
- Latent: addFavouriteBook creates immutable List.of() on null path → switched to ArrayList
- M2: InboxService status filter — use SwapStatus.fromCode().getCode() so case-insensitive input works
- M3: Duplicate swap requests — partial unique index via Mongock migration (order 005) + DuplicateKeyException handling
- M4: Swap-offer creation — guard null coverPhoto in swappableBookWithImageUrl
- M12: STOMP relay — add rabbitmq.host to cloud yaml with no default so misconfiguration fails fast
- L1: UserDao — add @Version for optimistic locking on concurrent user mutations
- L2: ChatController — replace O(n²) indexOf with indexed IntStream iteration
- L3: SwapService — validate ObjectId format before construction (400 not 500)
- L4: imageUrls cache TTL — reduce to 6 days in non-cloud profile (under MinIO 7-day expiry)
- L5: MongoIndexConfig — rename misleading createTextIndexes to createCityCountryIndexes; anchor city regex with ^ for btree use
- L6: OTPDao — add TTL index (20 min expiry on createdAt) and unique index on email; OTPService already does delete-then-save

Test additions:
- UserServiceTest: changePassword with null password (OAuth account) — no NPE
- UserServiceTest: addFavouriteBook twice with null initial favBooks — no UnsupportedOperationException
- InboxServiceTest: lowercase status string returns same results as canonical-case (M2 regression)
- NotificationServiceTest: updated to reflect findAndModify-based outbox processing (H2)
- OTPServiceTest: updated to use builder after OTPDao gained @Id field (L6)