### PR TITLE
Fix: add Mongock migration to initialise @Version field on existing users

### DIFF
--- a/src/main/java/com/kirjaswappi/backend/common/migrations/AddVersionFieldToUsers.java
+++ b/src/main/java/com/kirjaswappi/backend/common/migrations/AddVersionFieldToUsers.java
@@ -9,12 +9,16 @@ import io.mongock.api.annotations.Execution;
 import io.mongock.api.annotations.RollbackExecution;
 
 import org.bson.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
 import com.mongodb.client.result.UpdateResult;
 
 @ChangeUnit(id = "add-version-field-to-users", order = "006", author = "mahiuddinalkamal")
 public class AddVersionFieldToUsers {
+
+  private static final Logger logger = LoggerFactory.getLogger(AddVersionFieldToUsers.class);
 
   private final MongoTemplate mongoTemplate;
 
@@ -27,17 +31,23 @@ public class AddVersionFieldToUsers {
     // Initialise @Version field on all existing user documents that don't have it.
     // Without this, Spring Data treats version=null as a new entity and attempts
     // insert instead of update, causing E11000 duplicate _id errors.
-    UpdateResult result = mongoTemplate.getCollection("users").updateMany(
-        new Document("version", new Document("$exists", false)),
-        new Document("$set", new Document("version", 0L)));
-    System.out.printf("[AddVersionFieldToUsers] Initialised version=0 on %d user document(s)%n",
-        result.getModifiedCount());
+    UpdateResult result = mongoTemplate
+        .getCollection("users")
+        .updateMany(
+            new Document("version", new Document("$exists", false)),
+            new Document("$set", new Document("version", 0L)));
+    logger.info("Initialised version=0 on {} user document(s)", result.getModifiedCount());
   }
 
   @RollbackExecution
   public void rollbackMigration() {
-    mongoTemplate.getCollection("users").updateMany(
-        new Document(),
-        new Document("$unset", new Document("version", "")));
+    // Only unset version on documents that were set to exactly 0 by this migration.
+    // Documents with a higher version were already incremented by the application
+    // and should not be touched.
+    mongoTemplate
+        .getCollection("users")
+        .updateMany(
+            new Document("version", 0L),
+            new Document("$unset", new Document("version", "")));
   }
 }

--- a/src/main/java/com/kirjaswappi/backend/common/migrations/AddVersionFieldToUsers.java
+++ b/src/main/java/com/kirjaswappi/backend/common/migrations/AddVersionFieldToUsers.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 KirjaSwappi or KirjaSwappi affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+package com.kirjaswappi.backend.common.migrations;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+
+import org.bson.Document;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import com.mongodb.client.result.UpdateResult;
+
+@ChangeUnit(id = "add-version-field-to-users", order = "006", author = "mahiuddinalkamal")
+public class AddVersionFieldToUsers {
+
+  private final MongoTemplate mongoTemplate;
+
+  public AddVersionFieldToUsers(MongoTemplate mongoTemplate) {
+    this.mongoTemplate = mongoTemplate;
+  }
+
+  @Execution
+  public void executeMigration() {
+    // Initialise @Version field on all existing user documents that don't have it.
+    // Without this, Spring Data treats version=null as a new entity and attempts
+    // insert instead of update, causing E11000 duplicate _id errors.
+    UpdateResult result = mongoTemplate.getCollection("users").updateMany(
+        new Document("version", new Document("$exists", false)),
+        new Document("$set", new Document("version", 0L)));
+    System.out.printf("[AddVersionFieldToUsers] Initialised version=0 on %d user document(s)%n",
+        result.getModifiedCount());
+  }
+
+  @RollbackExecution
+  public void rollbackMigration() {
+    mongoTemplate.getCollection("users").updateMany(
+        new Document(),
+        new Document("$unset", new Document("version", "")));
+  }
+}


### PR DESCRIPTION
### Problem

PR #364 added `@Version` to `UserDao` for optimistic locking. On an existing production database, documents without a `version` field have `version = null` when loaded. Spring Data MongoDB treats `version = null` as a new entity and issues an INSERT instead of an UPDATE — causing:

```
E11000 duplicate key error collection: kirjaswappi.users index: _id_
```

This crashes any operation that saves a user document (delete book, block user, etc.).

### Fix

Mongock migration `006` (`AddVersionFieldToUsers`) sets `version: 0` on all existing user documents that don't already have the field. Runs automatically on next deploy before any user save.

```javascript
db.users.updateMany({ version: { $exists: false } }, { $set: { version: 0 } })
```

Rollback drops the field.