### PR TITLE
Fix: chat 'Could not load messages' — @Version optimistic-lock collision on concurrent opens

### DIFF
--- a/src/main/java/com/kirjaswappi/backend/service/ChatService.java
+++ b/src/main/java/com/kirjaswappi/backend/service/ChatService.java
@@ -270,14 +270,25 @@ public class ChatService {
     chatMessageRepository.markAsRead(swapRequestId, userId);
 
     // Also mark the swap request inbox item as read so the inbox endpoint returns
-    // unread=false
+    // unread=false. Use a targeted MongoTemplate field update instead of a full
+    // save(): loading the DAO and calling save() bumps its @Version, so concurrent
+    // chat opens (the client polls and refetches on focus) would collide on
+    // optimistic locking and surface as a 500 ("Could not load messages"). A direct
+    // $set touches only the read-receipt field and never the version.
     Instant now = Instant.now();
+    String readField;
     if (swapRequest.receiver().id().equals(userId)) {
-      swapRequest.readByReceiverAt(now);
-      swapRequestRepository.save(swapRequest);
+      readField = "readByReceiverAt";
     } else if (swapRequest.sender().id().equals(userId)) {
-      swapRequest.readBySenderAt(now);
-      swapRequestRepository.save(swapRequest);
+      readField = "readBySenderAt";
+    } else {
+      readField = null;
+    }
+    if (readField != null) {
+      mongoTemplate.updateFirst(
+          new Query(Criteria.where("_id").is(swapRequestId)),
+          new Update().set(readField, now),
+          SwapRequestDao.class);
     }
 
     // Clear unread count cache AFTER marking messages as read to ensure consistency

--- a/src/test/java/com/kirjaswappi/backend/service/ChatServiceTest.java
+++ b/src/test/java/com/kirjaswappi/backend/service/ChatServiceTest.java
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
@@ -535,6 +537,23 @@ class ChatServiceTest {
 
     // Then
     verify(chatMessageRepository).markAsRead("swap123", "64e8f5d1a2b3c4d5e6f78901");
+  }
+
+  @Test
+  @DisplayName("Should mark read via targeted field update, never save() (avoids @Version optimistic-lock collision on concurrent chat opens)")
+  void shouldMarkReadWithoutBumpingSwapRequestVersion() {
+    // Given
+    when(swapRequestRepository.findById("swap123")).thenReturn(Optional.of(swapRequestDao));
+    when(chatMessageRepository.markAsRead("swap123", "64e8f5d1a2b3c4d5e6f78901")).thenReturn(2L);
+
+    // When - receiver opens the chat
+    chatService.markMessagesAsRead("swap123", "64e8f5d1a2b3c4d5e6f78901");
+
+    // Then - read receipt is applied through a direct field update on
+    // MongoTemplate,
+    // and swapRequestRepository.save() (which touches @Version) is NEVER called.
+    verify(mongoTemplate).updateFirst(any(Query.class), any(Update.class), eq(SwapRequestDao.class));
+    verify(swapRequestRepository, never()).save(any());
   }
 
   @Test


### PR DESCRIPTION
### Problem

Opening a chat on an accepted swap intermittently failed with **"Could not load messages. Please try again."** (`GET /api/v1/swap-requests/{id}/chat` returning 500).

### Root cause

`ChatService.getChatMessages` (a read endpoint) calls `markMessagesAsRead`, which **always** did a full `swapRequestRepository.save(swapRequest)`. Since `SwapRequestDao` carries `@Version` (added recently for optimistic locking), every chat open bumps the version — even when the read-receipt timestamp doesn't change.

The frontend `useGetChatMessagesQuery` uses `pollingInterval` + `refetchOnFocus: true`, so two overlapping GETs both load version `N` and both save → the second throws `OptimisticLockingFailureException` → 500.

The `globalRetry` resilience4j config exists in `application.yaml` but **no `@Retry` annotation is applied anywhere**, so the failure is never retried and propagates to the client.

### Fix

Replace the load-mutate-`save()` with a targeted `MongoTemplate` `$set` on the read-receipt field (`readByReceiverAt` / `readBySenderAt`) only. A direct field update does not participate in optimistic locking, so concurrent chat opens no longer collide. `ChatService` already injects `MongoTemplate`.

Added a regression test (`shouldMarkReadWithoutBumpingSwapRequestVersion`) asserting the read path uses `mongoTemplate.updateFirst(...)` and **never** calls `swapRequestRepository.save(...)`.

### Verification

`mvn test` — 724/724 pass (includes the new regression test), including TestContainers integration tests against real MongoDB/Redis.